### PR TITLE
renovate: Add configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "enabled": true,
+  "prCreation": "not-pending",
+  "extends": [
+    "schedule:earlyMondays",
+    "config:base",
+    ":disableDependencyDashboard"
+  ],
+  "rust": {
+    "enabled": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "semanticCommits": "enabled",
+  "rangeStrategy": "bump"
+}


### PR DESCRIPTION
Add a renovate configuration.

Renovate can be installed using: https://docs.renovatebot.com/

The vendor packaging is not supported in renovate, so an alternative approach to packaging should be chosen instead.