### PR TITLE
add 10-second delay & add route

### DIFF
--- a/gnosis_vpn-lib/src/wireguard/mod.rs
+++ b/gnosis_vpn-lib/src/wireguard/mod.rs
@@ -98,6 +98,7 @@ impl ConnectSession {
 PrivateKey = {private_key}
 Address = {address}
 {listen_port_line}
+PostUp = sleep 10 && ip route add 10.128.0.1/32 dev %i metric 50 2>/dev/null || true
 
 [Peer]
 PublicKey = {public_key}


### PR DESCRIPTION
Necessary to avoid the following error on PopOs: 

2025-07-02T18:20:27.679619Z WARN gnosis_vpn_lib::connection: Immediate session ping failed session=Session[1422/udp] 2025-07-02T18:20:27.679675Z ERROR gnosis_vpn_lib::log_output:

>>!!>> It seems your node isn't exposing the configured internal_connection_port (1422) on UDP.
>>!!>> Please expose that port for both TCP and UDP.
>>!!>> Additionally add port mappings in your docker-compose.yml or to your docker run statement.
>>!!>> Alternatively, update your configuration file to use a different port.

Without this customization I have to execute the following command after wireguard is up:

sudo ip route add 10.128.0.0/9 dev wg0_gnosisvpn