### PR TITLE
feat: introduce an intermediate ping session to verify connection would work before opening main session with huge response buffer 

### DIFF
--- a/gnosis_vpn-lib/src/connection/mod.rs
+++ b/gnosis_vpn-lib/src/connection/mod.rs
@@ -935,7 +935,7 @@ impl Display for PhaseUp {
 impl Display for PhaseDown {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            PhaseDown::CloseTunnel(session, registration) => write!(f, "CloseTunnel({}, {})", session, registration),
+            PhaseDown::CloseTunnel(session, registration) => write!(f, "CloseTunnel({session}, {registration})"),
             PhaseDown::PrepareBridgeSession(registration) => write!(f, "PrepareBridgeSession({registration})"),
             PhaseDown::FixBridgeSession(registration) => write!(f, "FixBridgeSession({registration})"),
             PhaseDown::FixBridgeSessionClosing(session, registration) => {

--- a/gnosis_vpn-lib/src/connection/mod.rs
+++ b/gnosis_vpn-lib/src/connection/mod.rs
@@ -967,9 +967,9 @@ impl From<PhaseUp> for PhaseDown {
             PhaseUp::PrepareMainSession(registration) => PhaseDown::PrepareBridgeSession(registration),
             PhaseUp::FixMainSession(registration) => PhaseDown::PrepareBridgeSession(registration),
             PhaseUp::FixMainSessionClosing(session, registration) => PhaseDown::CloseTunnel(session, registration),
-            PhaseUp::PrepareMainTunnel(session, registration, since) => PhaseDown::CloseTunnel(session, registration),
-            PhaseUp::TunnelEstablished(session, registration, since) => PhaseDown::CloseTunnel(session, registration),
-            PhaseUp::MonitorTunnel(session, registration, since) => PhaseDown::CloseTunnel(session, registration),
+            PhaseUp::PrepareMainTunnel(session, registration, _since) => PhaseDown::CloseTunnel(session, registration),
+            PhaseUp::TunnelEstablished(session, registration, _since) => PhaseDown::CloseTunnel(session, registration),
+            PhaseUp::MonitorTunnel(session, registration, _since) => PhaseDown::CloseTunnel(session, registration),
             PhaseUp::TunnelBroken(session, registration) => PhaseDown::CloseTunnel(session, registration),
         }
     }

--- a/gnosis_vpn-lib/src/monitor.rs
+++ b/gnosis_vpn-lib/src/monitor.rs
@@ -27,6 +27,15 @@ impl Default for PingOptions {
     }
 }
 
+impl Error {
+    pub fn would_block(&self) -> bool {
+        match self {
+            Error::PingFailed(ping::Error::IoError { error: err }) => err.kind() == std::io::ErrorKind::WouldBlock,
+            _ => false,
+        }
+    }
+}
+
 pub fn ping(opts: &PingOptions) -> Result<(), Error> {
     ping::ping(
         opts.address,

--- a/gnosis_vpn-lib/src/session/mod.rs
+++ b/gnosis_vpn-lib/src/session/mod.rs
@@ -16,7 +16,11 @@ pub use protocol::Protocol;
 mod path;
 mod protocol;
 
-const BRIDGE_BUFFER_SIZE: &str = "176B";
+// derived from wireshark observed response
+const BRIDGE_RESP_BUFFER_SIZE: &str = "473B";
+// derived from wireshark observed response: Handshake ack 134 + Ping ack 138
+const INITIAL_MAIN_RESP_BUFFER_SIZE: &str = "272B";
+const WORKING_MAIN_RESP_BUFFER_SIZE: &str = "5MB";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Session {
@@ -125,7 +129,7 @@ impl OpenSession {
             path: path.clone(),
             target: target.clone(),
             protocol: Protocol::Tcp,
-            response_buffer: BRIDGE_BUFFER_SIZE.to_string(),
+            response_buffer: BRIDGE_RESP_BUFFER_SIZE.to_string(),
         }
     }
 

--- a/gnosis_vpn-lib/src/session/mod.rs
+++ b/gnosis_vpn-lib/src/session/mod.rs
@@ -133,7 +133,7 @@ impl OpenSession {
         }
     }
 
-    pub fn initial_main(
+    pub fn ping(
         entry_node: EntryNode,
         destination: Address,
         capabilities: Vec<Capability>,

--- a/gnosis_vpn-lib/src/session/mod.rs
+++ b/gnosis_vpn-lib/src/session/mod.rs
@@ -16,6 +16,8 @@ pub use protocol::Protocol;
 mod path;
 mod protocol;
 
+const BRIDGE_BUFFER_SIZE: &str = "176B";
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Session {
     pub destination: Address,
@@ -51,6 +53,8 @@ pub struct OpenSession {
     path: Path,
     target: Target,
     protocol: Protocol,
+    // https://docs.rs/bytesize/2.0.1/bytesize/ string
+    response_buffer: String,
 }
 
 pub struct CloseSession {
@@ -121,6 +125,7 @@ impl OpenSession {
             path: path.clone(),
             target: target.clone(),
             protocol: Protocol::Tcp,
+            response_buffer: BRIDGE_BUFFER_SIZE.to_string(),
         }
     }
 
@@ -138,6 +143,7 @@ impl OpenSession {
             path: path.clone(),
             target: target.clone(),
             protocol: Protocol::Udp,
+            response_buffer: "5MB".to_string(),
         }
     }
 }
@@ -188,6 +194,7 @@ impl Session {
         json.insert("listenHost".to_string(), json!(&open_session.entry_node.listen_host));
 
         json.insert("capabilities".to_string(), json!(open_session.capabilities));
+        json.insert("responseBuffer".to_string(), json!(open_session.response_buffer));
         // creates a TCP session as part of the session pool, so we immediately know if it might work
         if open_session.protocol == Protocol::Tcp {
             json.insert("sessionPool".to_string(), json!(1));

--- a/gnosis_vpn-lib/src/session/mod.rs
+++ b/gnosis_vpn-lib/src/session/mod.rs
@@ -20,7 +20,7 @@ mod protocol;
 const BRIDGE_RESP_BUFFER_SIZE: &str = "473B";
 // derived from wireshark observed response: Handshake ack 134 + Ping ack 138
 const INITIAL_MAIN_RESP_BUFFER_SIZE: &str = "272B";
-const WORKING_MAIN_RESP_BUFFER_SIZE: &str = "5MB";
+const MAIN_RESP_BUFFER_SIZE: &str = "5MB";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Session {
@@ -133,6 +133,24 @@ impl OpenSession {
         }
     }
 
+    pub fn initial_main(
+        entry_node: EntryNode,
+        destination: Address,
+        capabilities: Vec<Capability>,
+        path: Path,
+        target: Target,
+    ) -> Self {
+        OpenSession {
+            entry_node: entry_node.clone(),
+            destination,
+            capabilities,
+            path: path.clone(),
+            target: target.clone(),
+            protocol: Protocol::Udp,
+            response_buffer: INITIAL_MAIN_RESP_BUFFER_SIZE.to_string(),
+        }
+    }
+
     pub fn main(
         entry_node: EntryNode,
         destination: Address,
@@ -147,7 +165,7 @@ impl OpenSession {
             path: path.clone(),
             target: target.clone(),
             protocol: Protocol::Udp,
-            response_buffer: "5MB".to_string(),
+            response_buffer: MAIN_RESP_BUFFER_SIZE.to_string(),
         }
     }
 }

--- a/gnosis_vpn/src/event.rs
+++ b/gnosis_vpn/src/event.rs
@@ -10,7 +10,7 @@ pub enum Event {
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Event::ConnectionEvent(event) => write!(f, "ConnectionEvent: {}", event),
+            Event::ConnectionEvent(event) => write!(f, "ConnectionEvent: {event}"),
         }
     }
 }

--- a/gnosis_vpn/src/event.rs
+++ b/gnosis_vpn/src/event.rs
@@ -6,6 +6,7 @@ pub enum Event {
     ConnectWg,
     /// Boolean flag indicates if it has ever worked before, true meaning it has worked at least once.
     Disconnected(bool),
+    Broken,
     DropConnection,
 }
 
@@ -15,6 +16,7 @@ impl fmt::Display for Event {
             Event::ConnectWg => write!(f, "ConnectWg"),
             Event::Disconnected(true) => write!(f, "Disconnected (ping has worked)"),
             Event::Disconnected(false) => write!(f, "Disconnected (ping never worked)"),
+            Event::Broken => write!(f, "Broken"),
             Event::DropConnection => write!(f, "DropConnection"),
         }
     }

--- a/gnosis_vpn/src/event.rs
+++ b/gnosis_vpn/src/event.rs
@@ -1,23 +1,16 @@
 use std::fmt;
 
+use gnosis_vpn_lib::connection;
+
 #[derive(Debug)]
 pub enum Event {
-    /// Event indicating that the connection has been established and is ready for use.
-    ConnectWg,
-    /// Boolean flag indicates if it has ever worked before, true meaning it has worked at least once.
-    Disconnected(bool),
-    Broken,
-    DropConnection,
+    ConnectionEvent(connection::Event),
 }
 
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Event::ConnectWg => write!(f, "ConnectWg"),
-            Event::Disconnected(true) => write!(f, "Disconnected (ping has worked)"),
-            Event::Disconnected(false) => write!(f, "Disconnected (ping never worked)"),
-            Event::Broken => write!(f, "Broken"),
-            Event::DropConnection => write!(f, "DropConnection"),
+            Event::ConnectionEvent(event) => write!(f, "ConnectionEvent: {}", event),
         }
     }
 }

--- a/justfile
+++ b/justfile
@@ -208,8 +208,9 @@ system-setup mode='keep-running': submodules docker-build
             exit 1
         )
 
-        echo "[PHASE3] Waiting for 40 seconds to ensure connection stability"
-        sleep 40
+        echo "[PHASE3] Waiting for 30 seconds to ensure connection stability"
+        echo "[PHASE3] This will remove the client from the server and the client has to recover"
+        sleep 30
 
         echo "[PHASE3] Checking external ping again"
         time docker exec gnosis_vpn-client ping -c1 10.129.0.1 || (
@@ -227,12 +228,9 @@ system-setup mode='keep-running': submodules docker-build
         docker exec gnosis_vpn-client ./gnosis_vpn-ctl disconnect
         exp_client_log "connection closed" 11
 
-        echo "[PHASE3] Checking no warnings or errors in client logs"
-        if docker logs gnosis_vpn-client | grep -qE "WARN|ERROR"; then
-            echo "[PHASE3] Found warnings or errors in client logs"
-            docker logs gnosis_vpn-client
-            exit 1
-        fi
+        echo "[PHASE3] Print client logs for manual verification"
+        docker logs gnosis_vpn-client
+
         echo "[PHASE3] Checking no errors in server logs"
         if docker logs gnosis_vpn-server | grep -qE "ERROR"; then
             echo "[PHASE3] Found errors in server logs"

--- a/justfile
+++ b/justfile
@@ -210,7 +210,7 @@ system-setup mode='keep-running': submodules docker-build
 
         echo "[PHASE3] Waiting for 30 seconds to ensure connection stability"
         echo "[PHASE3] This will remove the client from the server and the client has to recover"
-        sleep 30
+        sleep 40
 
         echo "[PHASE3] Checking external ping again"
         time docker exec gnosis_vpn-client ping -c1 10.129.0.1 || (


### PR DESCRIPTION
This will be obsoleted when the response buffer for an existing session becomes changeable via API