### PR TITLE
refactor: Use anyhow result in unit tests

### DIFF
--- a/gnosis_vpn-lib/src/chain/client.rs
+++ b/gnosis_vpn-lib/src/chain/client.rs
@@ -77,33 +77,35 @@ impl GnosisRpcClient {
 mod tests {
     use super::*;
     use alloy::node_bindings::Anvil;
+    use anyhow::Ok;
 
     #[tokio::test]
-    async fn test_client_creation_with_default_url() {
+    async fn test_client_creation_with_default_url() -> anyhow::Result<()> {
         let default_signer = ChainKeypair::random();
         let client = GnosisRpcClient::new(default_signer).await;
         assert!(client.is_ok());
 
-        let client = client.unwrap();
+        let client = client?;
         assert_eq!(client.rpc_url(), DEFAULT_GNOSIS_RPC_URL);
+        Ok(())
     }
 
     #[tokio::test]
-    #[ignore = "broken - needs fix"]
-    async fn test_client_creation_with_custom_url() {
+    async fn test_client_creation_with_custom_url() -> anyhow::Result<()> {
         let anvil = Anvil::new().spawn();
         let default_signer = ChainKeypair::random();
         let custom_url = anvil.endpoint();
         let client = GnosisRpcClient::with_url(default_signer, custom_url.as_str()).await;
         assert!(client.is_ok());
 
-        let client = client.unwrap();
+        let client = client?;
         assert_eq!(client.rpc_url(), custom_url);
 
         let chain_id = client.get_chain_id().await;
 
         // Gnosis chain ID is 31337
         assert!(chain_id.is_ok());
-        assert_eq!(chain_id.unwrap(), 31337);
+        assert_eq!(chain_id?, 31337);
+        Ok(())
     }
 }

--- a/gnosis_vpn-lib/src/chain/contracts.rs
+++ b/gnosis_vpn-lib/src/chain/contracts.rs
@@ -160,7 +160,7 @@ impl CheckBalanceInputs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{address, hex, uint};
+    use alloy::primitives::{U256, address, hex};
 
     #[test]
     fn test_build_default_target() {
@@ -171,8 +171,8 @@ mod tests {
 
     #[test]
     fn test_safe_module_deployment_user_data_encoding() {
-        let nonce = uint!(999_U256);
-        let token_amount = uint!(500000000000000000_U256); // 0.5 tokens
+        let nonce = U256::from(999);
+        let token_amount = U256::from(500000000000000000u64); // 0.5 tokens
         let admins = vec![
             address!("0x1111111111111111111111111111111111111111"),
             address!("0x2222222222222222222222222222222222222222"),


### PR DESCRIPTION
### Description
- Replace `unwrap()` used in unit tests with anyhow::Result
- Enable `test_client_creation_with_custom_url`