### PR TITLE
fix: change default socket path and make sure the dirs in the path exist

### DIFF
--- a/gnosis_vpn-lib/src/socket.rs
+++ b/gnosis_vpn-lib/src/socket.rs
@@ -22,7 +22,7 @@ pub enum Error {
     ReadSocketIO(io::Error),
 }
 
-pub const DEFAULT_PATH: &str = "/var/run/gnosis_vpn.sock";
+pub const DEFAULT_PATH: &str = "/var/run/gnosis_vpn/gnosis_vpn.sock";
 pub const ENV_VAR: &str = "GNOSISVPN_SOCKET_PATH";
 
 // #[cfg(target_family = "windows")]


### PR DESCRIPTION
This pull request improves the robustness of the socket file handling in the Gnosis VPN daemon by updating the default socket path and ensuring the socket directory is created before binding. These changes help prevent errors when the socket directory does not exist and clarify the default location of the socket file.

**Socket path and directory handling improvements:**

* Changed the default socket path in `DEFAULT_PATH` to `/var/run/gnosis_vpn/gnosis_vpn.sock` to better organize socket files.
* Added logic to create the parent directory for the socket path if it does not exist, preventing binding errors due to missing directories.

**Code organization:**

* Moved the assignment of `socket_path` in the `daemon` function to ensure correct ordering and clarity.