### PR TITLE
feat(allocator): update the node to be able to use different allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.37"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6cfe35f100bc496007c9a00f90b88bdf565f1421d4c707c9f07e0717e2aaad"
+checksum = "0e84ab07ca0c3210734019e4d0e5392952ed574196ab0f904ab9c7ba0ae15595"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "1.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=ff930b7321b687b0f647d232ffedeea7b2b1c683#ff930b7321b687b0f647d232ffedeea7b2b1c683"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=60aa59402979368114dc512dda757f6c804478a3#60aa59402979368114dc512dda757f6c804478a3"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "hopr-async-runtime"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "futures",
  "tokio",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-actions"
 version = "0.10.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "async-lock 3.4.1",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-api"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "async-trait",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-config"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "anyhow",
  "hopr-chain-types",
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-indexer"
 version = "0.10.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "async-compression",
@@ -4448,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-rpc"
 version = "0.7.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "async-stream",
@@ -4481,8 +4481,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-types"
-version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.10.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "hex-literal",
@@ -4494,6 +4494,7 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "serde",
+ "serde_with",
  "strum 0.27.2",
  "thiserror 2.0.17",
  "tracing",
@@ -4502,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-keypair"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "hex",
  "hopr-crypto-random",
@@ -4521,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "flagset",
  "hex",
@@ -4531,7 +4532,6 @@ dependencies = [
  "hopr-internal-types",
  "hopr-path",
  "hopr-primitive-types",
- "mimalloc",
  "serde",
  "serde_bytes",
  "strum 0.27.2",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-random"
 version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "generic-array 1.3.5",
  "rand 0.8.5",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-sphinx"
 version = "0.10.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4570,8 +4570,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-types"
-version = "0.7.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.7.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "aes",
  "blake3",
@@ -4588,7 +4588,6 @@ dependencies = [
  "hopr-primitive-types",
  "k256",
  "libp2p-identity",
- "mimalloc",
  "poly1305",
  "primitive-types 0.14.0",
  "secp256k1 0.31.1",
@@ -4605,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-entity"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4625,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-migration"
 version = "0.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "hopr-internal-types",
  "hopr-primitive-types",
@@ -4636,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-node"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-lock 3.4.1",
  "async-stream",
@@ -4674,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "hopr-db-sql"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4685,7 +4684,6 @@ dependencies = [
  "hopr-db-entity",
  "hopr-db-migration",
  "hopr-internal-types",
- "hopr-platform",
  "hopr-primitive-types",
  "moka",
  "multiaddr",
@@ -4701,8 +4699,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-internal-types"
-version = "0.11.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.12.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "aquamarine",
  "hex-literal",
@@ -4722,9 +4720,10 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "3.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
+ "anyhow",
  "async-lock 3.4.1",
  "async-trait",
  "atomic_enum",
@@ -4770,15 +4769,15 @@ dependencies = [
 [[package]]
 name = "hopr-metrics"
 version = "1.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "prometheus",
 ]
 
 [[package]]
 name = "hopr-network-types"
-version = "1.0.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "1.1.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4810,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "hopr-parallelize"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "futures",
  "rayon",
@@ -4818,8 +4817,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-path"
-version = "0.8.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.9.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-lock 3.4.1",
  "async-trait",
@@ -4834,7 +4833,6 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "strum 0.27.2",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -4842,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-platform"
 version = "0.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4850,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "hopr-primitive-types"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "alloy",
  "bigdecimal",
@@ -4869,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-primitive-types",
@@ -4882,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.0.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4899,7 +4897,6 @@ dependencies = [
  "hopr-metrics",
  "hopr-primitive-types",
  "lazy_static",
- "mimalloc",
  "parking_lot",
  "pin-project",
  "ringbuffer",
@@ -4915,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.0.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "aquamarine",
  "hopr-crypto-packet",
@@ -4929,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.15.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-trait",
  "futures",
@@ -4938,7 +4935,6 @@ dependencies = [
  "hopr-crypto-types",
  "hopr-internal-types",
  "hopr-metrics",
- "hopr-platform",
  "hopr-primitive-types",
  "hopr-transport-protocol",
  "lazy_static",
@@ -4953,8 +4949,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.14.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.15.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-lock 3.4.1",
  "async-trait",
@@ -4995,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-bloom"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "bloomfilter",
  "hopr-crypto-random",
@@ -5006,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-identity"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "libp2p-identity",
  "multiaddr",
@@ -5016,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5032,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-network"
 version = "0.8.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "futures",
  "hopr-api",
@@ -5057,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.8.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "async-trait",
  "futures",
@@ -5076,8 +5072,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5110,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-protocol"
 version = "0.11.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5150,8 +5146,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.13.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=4f02881b586670566655b866dfbc9ebc53c8cd31#4f02881b586670566655b866dfbc9ebc53c8cd31"
+version = "0.13.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=620a80baa5a4fdb7d554dfc86d6c1b58c2882317#620a80baa5a4fdb7d554dfc86d6c1b58c2882317"
 dependencies = [
  "arrayvec",
  "async-trait",
@@ -5170,7 +5166,6 @@ dependencies = [
  "hopr-protocol-session",
  "hopr-protocol-start",
  "lazy_static",
- "mimalloc",
  "moka",
  "pid",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "LGPL-3.0"
 name = "gnosis_vpn"
 
 [workspace.dependencies]
-alloy = { version = "=1.0.37", default-features = false, features = [
+alloy = { version = "=1.0.42", default-features = false, features = [
   "essentials",
   "json-rpc",
   "node-bindings",
@@ -49,7 +49,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 tokio = { version = "1.48.0", features = ["full"] }
 url = { version = "2.5.7", features = ["serde"] }
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "ff930b7321b687b0f647d232ffedeea7b2b1c683", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "60aa59402979368114dc512dda757f6c804478a3", features = [
   "prometheus",
 ] }
 serde_with = "3.15.1"

--- a/gnosis_vpn-lib/src/config/mod.rs
+++ b/gnosis_vpn-lib/src/config/mod.rs
@@ -1,5 +1,5 @@
 use edgli::hopr_lib::exports::network::types::types::RoutingOptions;
-use edgli::hopr_lib::{Address, GeneralError};
+use edgli::hopr_lib::{Address, GeneralError, NodeId};
 use thiserror::Error;
 
 use std::collections::HashMap;
@@ -46,6 +46,10 @@ impl Config {
             .values()
             .filter_map(|d| match d.routing.clone() {
                 RoutingOptions::IntermediatePath(path) => path.into_iter().next(),
+                _ => None,
+            })
+            .filter_map(|node_id| match node_id {
+                NodeId::Chain(address) => Some(address),
                 _ => None,
             })
             .collect()

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -1,4 +1,5 @@
 use bytesize::ByteSize;
+use edgli::hopr_lib::NodeId;
 use edgli::hopr_lib::exports::network::types::types::{IpOrHost, RoutingOptions, SealedHost};
 use edgli::hopr_lib::{Address, SessionCapabilities, SessionCapability, SessionTarget};
 use human_bandwidth::re::bandwidth::Bandwidth;
@@ -399,7 +400,9 @@ pub fn convert_destinations(
     let mut result = HashMap::new();
     for (address, dest) in config_dests.iter() {
         let path = match dest.path.clone() {
-            Some(DestinationPath::Intermediates(p)) => RoutingOptions::IntermediatePath(p.try_into()?),
+            Some(DestinationPath::Intermediates(p)) => {
+                RoutingOptions::IntermediatePath(p.into_iter().map(|v| NodeId::from(v)).collect())
+            }
             Some(DestinationPath::Hops(h)) => RoutingOptions::Hops(h.try_into()?),
             None => RoutingOptions::Hops(1.try_into()?),
         };


### PR DESCRIPTION
This pull request updates dependencies and refines the handling of node identifiers in the VPN configuration logic. The most important changes are grouped below by theme.

**Dependency updates:**

* Updated the `alloy` crate from version `1.0.37` to `1.0.42` in `Cargo.toml`.
* Updated the `edgli` dependency to a newer git revision in `Cargo.toml`.

**Node identifier handling improvements:**

* Added import of `NodeId` from `edgli::hopr_lib` in `gnosis_vpn-lib/src/config/mod.rs` and `gnosis_vpn-lib/src/config/v4.rs` to enable more precise node identification. [[1]](diffhunk://#diff-1e1ed23a2f9d3bc3f966873ecf703345ea2004df3b5fac37e4c12e29bd7c1692L2-R2) [[2]](diffhunk://#diff-66c45c095d743334a51c6869af049ddca32066dcc2d63e4b9c88ade51e47c87fR2)
* Enhanced the `Config::get_intermediate_addresses` method to filter and extract addresses only from `NodeId::Chain` variants, improving correctness when retrieving intermediate node addresses.
* Modified the `convert_destinations` function to construct `RoutingOptions::IntermediatePath` using `NodeId` values, ensuring consistent type usage for routing paths.