### PR TITLE
Increase build binaries timeout to 2h

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -39,7 +39,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, format('binary:{0}', inputs.architecture))) || (github.event_name == 'pull_request' && github.event.pull_request.merged)
     runs-on: ${{ github.event.inputs.runner || inputs.runner }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Set environment variables
         id: vars


### PR DESCRIPTION
Using 90 minutes it's not enough