### PR TITLE
fix: Fixes the bump version using a token from bot user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN}}
       - name: Setup GCP
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@master


### PR DESCRIPTION
- The close release workflow was failing because it required special permissions to bump the version.
- A bot user has been created and the workflow now runs using the token from the bot instead of the invoker user.
- The protection rule for `main` is enabled again as it will work with this PR