### PR TITLE
feat(cfg): update configurability of the mixer characteristics in the worker process

### DIFF
--- a/gnosis_vpn-root/src/main.rs
+++ b/gnosis_vpn-root/src/main.rs
@@ -212,8 +212,8 @@ async fn loop_daemon(
         .current_dir(&worker_user.home)
         .env(socket::worker::ENV_VAR, format!("{}", child_socket.into_raw_fd()))
         .env("HOME", &worker_user.home)
-        .env("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS", "0")    // the client does not want to mix
-        .env("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS", "1")      // the mix range must be minimal to retain the QoS of the client
+        .env("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS", "0") // the client does not want to mix
+        .env("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS", "1") // the mix range must be minimal to retain the QoS of the client
         .uid(worker_user.uid)
         .gid(worker_user.gid)
         .spawn()


### PR DESCRIPTION
This pull request makes a small change to the environment configuration for the worker process in `gnosis_vpn-root/src/main.rs`. Two new environment variables are set to control the internal mixer delay for the HOPR service, likely for testing or performance tuning purposes.

- Environment configuration:
  * Set `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` to `"0"` and `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` to `"1"` when spawning the worker process in `loop_daemon`.