### PR TITLE
fix: use correct argument ordering in route syntax

### DIFF
--- a/gnosis_vpn-lib/src/wireguard.rs
+++ b/gnosis_vpn-lib/src/wireguard.rs
@@ -172,10 +172,10 @@ impl WireGuard {
         {
             // on macos to avoid fighting router specific rules we split the range in two
             // this way the routes are more specific and take precedence over other rules
-            lines.push("PostUp = route -n add -blackhole -inet6 ::/1 -inet6 ::1".to_string());
-            lines.push("PostUp = route -n add -blackhole -inet6 8000::/1 -inet6 ::1".to_string());
-            lines.push("PreDown = route -n delete -blackhole -inet6 ::/1 -inet6 ::1".to_string());
-            lines.push("PreDown = route -n delete -blackhole -inet6 8000::/1 -inet6 ::1".to_string());
+            lines.push("PostUp = route -n add -blackhole -inet6 ::/1 ::1".to_string());
+            lines.push("PostUp = route -n add -blackhole -inet6 8000::/1 ::1".to_string());
+            lines.push("PreDown = route -n delete -blackhole -inet6 ::/1 ::1".to_string());
+            lines.push("PreDown = route -n delete -blackhole -inet6 8000::/1 ::1".to_string());
         }
 
         lines.push("".to_string()); // Empty line for spacing


### PR DESCRIPTION
This pull request makes a minor adjustment to the WireGuard configuration commands for macOS, specifically changing the order of flags in the route commands to improve clarity and compatibility.

* Changed the order of flags in the `PostUp` and `PreDown` route commands for IPv6 blackhole routes in the `WireGuard` implementation, placing `-blackhole` before `-inet6` for consistency and correctness. (`gnosis_vpn-lib/src/wireguard.rs`, [gnosis_vpn-lib/src/wireguard.rsL175-R178](diffhunk://#diff-4bba6dad20ea1e018a7fa05a4b4d143a3b15d8e328985ad68e740a205ecfac1bL175-R178))