### PR TITLE
feat: Allow to specify the static routing via env var

### DIFF
--- a/gnosis_vpn-lib/src/worker.rs
+++ b/gnosis_vpn-lib/src/worker.rs
@@ -43,6 +43,7 @@ pub const DEFAULT_WORKER_BINARY: &str = "./gnosis_vpn-worker";
 pub const DEFAULT_WORKER_USER: &str = USERNAME;
 pub const ENV_VAR_WORKER_BINARY: &str = "GNOSISVPN_WORKER_BINARY";
 pub const ENV_VAR_WORKER_USER: &str = "GNOSISVPN_WORKER_USER";
+pub const ENV_VAR_FORCE_STATIC_ROUTING: &str = "GNOSISVPN_FORCE_STATIC_ROUTING";
 
 #[derive(Debug, Clone)]
 pub struct Worker {

--- a/gnosis_vpn-root/src/cli.rs
+++ b/gnosis_vpn-root/src/cli.rs
@@ -78,7 +78,7 @@ pub struct Cli {
     pub allow_insecure: bool,
 
     /// Avoid dynamic peer discovery while connected to the VPN
-    #[arg(long)]
+    #[arg(long, env = worker::ENV_VAR_FORCE_STATIC_ROUTING)]
     pub force_static_routing: bool,
 }
 


### PR DESCRIPTION
Allow to specify the parameter `--force-static-routing` also via the environment variable named `GNOSISVPN_FORCE_STATIC_ROUTING`