### PR TITLE
fix: do not publish the multiaddress on chain

### DIFF
--- a/gnosis_vpn-lib/src/hopr/config.rs
+++ b/gnosis_vpn-lib/src/hopr/config.rs
@@ -63,8 +63,7 @@ host:
 safe_module:
     safe_address: {safe_address}
     module_address: {module_address}
-publish:
-    false
+publish: false
 "##,
         port = rand::rng().random_range(20000..65000),
         safe_address = safe_module.safe_address,


### PR DESCRIPTION
Do not announce on chain, just do the keybindings.

- Added `publish: false` to the configuration template in `gnosis_vpn-lib/src/hopr/config.rs` to control service publication.