### PR TITLE
fix: log file permissions

### DIFF
--- a/gnosis_vpn-lib/src/logging.rs
+++ b/gnosis_vpn-lib/src/logging.rs
@@ -49,7 +49,7 @@ pub fn make_file_fmt_layer(log_path: &str, worker: &Worker) -> Result<FileFmtLay
     let file = OpenOptions::new()
         .create(true)
         .append(true)
-        .mode(0o644)
+        .mode(0o046)
         .open(log_path)?;
 
     fs::chown(log_path, Some(worker.uid), Some(worker.gid))?;


### PR DESCRIPTION
This PR gives enough permissions to the user to update the log file. Also set the world permission level to 0.

This should only be a workaround, as the easiest way to handle multiple users from different group generating logs (`gnosisvpn:gnosisvpn` and `root` from the `worker` and the `root`) would be to split the logs files for those users.