### PR TITLE
routing: improve Both exit nodes unreachable after fresh Gnosis

### DIFF
--- a/gnosis_vpn-root/src/routing/macos.rs
+++ b/gnosis_vpn-root/src/routing/macos.rs
@@ -206,6 +206,7 @@ impl<R: RouteOps + 'static, W: WgOps + 'static> Routing for StaticRouter<R, W> {
             bypass_manager.teardown().await;
         }
         self.bypass_manager = None;
+        self.wg_interface_name = None;
     }
 }
 


### PR DESCRIPTION
## Summary

Both exit nodes unreachable after fresh Gnosis VPN install on Rotsee network — modified `gnosis_vpn-root/src/routing/macos.rs`.

Refs #455

## Changes

- gnosis_vpn-root/src/routing/macos.rs (+1)

## Rationale

Applied fix for Both exit nodes unreachable after fresh Gnosis VPN install on Rotsee network in `macos.rs`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to gnosis_vpn-root/src/routing/macos.rs.

## Validation

Basic lint and formatting checks passed.