### PR TITLE
fix: rewrite nix libiconv dylib paths to system lib on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ result/bin/:
 total 4752
 -r-xr-xr-x 1 root root  4863367 Jan  1  1970 gnosis_vpn-root
 -r-xr-xr-x 1 root root 14863367 Jan  1  1970 gnosis_vpn-worker
--r-xr-xr-x 1 root root  1740056 Jan  1  1970 gnosis_vpn-ctl
+-r-xr-xr-x 1 root root  1740057 Jan  1  1970 gnosis_vpn-ctl
 ```

--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ result/bin/:
 total 4752
 -r-xr-xr-x 1 root root  4863367 Jan  1  1970 gnosis_vpn-root
 -r-xr-xr-x 1 root root 14863367 Jan  1  1970 gnosis_vpn-worker
--r-xr-xr-x 1 root root  1740057 Jan  1  1970 gnosis_vpn-ctl
+-r-xr-xr-x 1 root root  1740058 Jan  1  1970 gnosis_vpn-ctl
 ```

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -127,22 +127,24 @@ let
   # libiconv references to /usr/lib so the binary works outside of Nix.
   withDarwinStaticFlags =
     drv:
-    drv.overrideAttrs (_: {
+    drv.overrideAttrs (prev: {
       CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv";
 
-      postInstall = lib.optionalString pkgs.stdenv.isDarwin ''
-        for bin in $(find "$out/bin" -type f); do
-          linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
+      postInstall =
+        lib.optionalString (prev ? postInstall && prev.postInstall != null) prev.postInstall
+        + lib.optionalString pkgs.stdenv.isDarwin ''
+          for bin in $(find "$out/bin" -type f); do
+            linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
 
-          if [ -n "$linked_iconv" ]; then
-            echo "Rewriting $bin - found nix libiconv reference: $linked_iconv"
-            install_name_tool -change "$linked_iconv" "/usr/lib/libiconv.2.dylib" "$bin"
-            echo "Fixed libiconv path"
-          else
-            echo "Not rewriting $bin - no nix libiconv reference found"
-          fi
-        done
-      '';
+            if [ -n "$linked_iconv" ]; then
+              echo "Rewriting $bin - found nix libiconv reference: $linked_iconv"
+              install_name_tool -change "$linked_iconv" "/usr/lib/libiconv.2.dylib" "$bin"
+              echo "Fixed libiconv path"
+            else
+              echo "Not rewriting $bin - no nix libiconv reference found"
+            fi
+          done
+        '';
     });
 
   mkGnosisvpnBuildArgs =

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -122,9 +122,9 @@ let
     }
   );
 
-  # Darwin: append +crt-static and system libiconv to nix-lib's existing RUSTFLAGS,
-  # then rewrite any Nix store libiconv references to /usr/lib so the binary works
-  # outside of Nix.
+  # Darwin: set CARGO_BUILD_RUSTFLAGS with +crt-static and system libiconv flags,
+  # overriding any value previously set by nix-lib, then rewrite any Nix store
+  # libiconv references to /usr/lib so the binary works outside of Nix.
   withDarwinStaticFlags =
     drv:
     drv.overrideAttrs (_: {

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -132,7 +132,7 @@ let
 
       postInstall =
         lib.optionalString (prev ? postInstall && prev.postInstall != null) prev.postInstall
-        + lib.optionalString pkgs.stdenv.isDarwin ''
+        + ''
           for bin in $(find "$out/bin" -type f); do
             linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
 

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -127,26 +127,22 @@ let
   # outside of Nix.
   withDarwinStaticFlags =
     drv:
-    drv.overrideAttrs (prev: {
-      CARGO_BUILD_RUSTFLAGS = "${
-        prev.CARGO_BUILD_RUSTFLAGS or ""
-      } -C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv";
+    drv.overrideAttrs (_: {
+      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv";
 
-      postInstall =
-        (prev.postInstall or "")
-        + lib.optionalString pkgs.stdenv.isDarwin ''
-          for bin in $(find "$out/bin" -type f); do
-            linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
+      postInstall = lib.optionalString pkgs.stdenv.isDarwin ''
+        for bin in $(find "$out/bin" -type f); do
+          linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
 
-            if [ -n "$linked_iconv" ]; then
-              echo "Rewriting $bin - found nix libiconv reference: $linked_iconv"
-              install_name_tool -change "$linked_iconv" "/usr/lib/libiconv.2.dylib" "$bin"
-              echo "Fixed libiconv path"
-            else
-              echo "Not rewriting $bin - no nix libiconv reference found"
-            fi
-          done
-        '';
+          if [ -n "$linked_iconv" ]; then
+            echo "Rewriting $bin - found nix libiconv reference: $linked_iconv"
+            install_name_tool -change "$linked_iconv" "/usr/lib/libiconv.2.dylib" "$bin"
+            echo "Fixed libiconv path"
+          else
+            echo "Not rewriting $bin - no nix libiconv reference found"
+          fi
+        done
+      '';
     });
 
   mkGnosisvpnBuildArgs =

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -122,13 +122,31 @@ let
     }
   );
 
-  # Darwin: append +crt-static and system libiconv to nix-lib's existing RUSTFLAGS.
+  # Darwin: append +crt-static and system libiconv to nix-lib's existing RUSTFLAGS,
+  # then rewrite any Nix store libiconv references to /usr/lib so the binary works
+  # outside of Nix.
   withDarwinStaticFlags =
     drv:
     drv.overrideAttrs (prev: {
       CARGO_BUILD_RUSTFLAGS = "${
         prev.CARGO_BUILD_RUSTFLAGS or ""
       } -C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv";
+
+      postInstall =
+        (prev.postInstall or "")
+        + lib.optionalString pkgs.stdenv.isDarwin ''
+          for bin in $(find "$out/bin" -type f); do
+            linked_iconv=$(otool -L "$bin" | grep "/nix/store/.*libiconv.*dylib" | awk '{print $1}')
+
+            if [ -n "$linked_iconv" ]; then
+              echo "Rewriting $bin - found nix libiconv reference: $linked_iconv"
+              install_name_tool -change "$linked_iconv" "/usr/lib/libiconv.2.dylib" "$bin"
+              echo "Fixed libiconv path"
+            else
+              echo "Not rewriting $bin - no nix libiconv reference found"
+            fi
+          done
+        '';
     });
 
   mkGnosisvpnBuildArgs =


### PR DESCRIPTION
The darwin build links against Nix store libiconv at build time, but the resulting binary records that store path. On machines without the exact Nix store entry, dyld fails to load it. The postInstall hook uses install_name_tool to rewrite references to /usr/lib/libiconv.2.dylib.

This was lost in transition when consolidating the workflows