### PR TITLE
feat: get identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ dependencies = [
  "exitcode",
  "gnosis_vpn-lib",
  "humantime",
+ "libc",
  "mimalloc",
  "reqwest 0.13.2",
  "serde",

--- a/gnosis_vpn-ctl/Cargo.toml
+++ b/gnosis_vpn-ctl/Cargo.toml
@@ -9,6 +9,7 @@ clap.workspace           = true
 exitcode.workspace       = true
 gnosis_vpn-lib.workspace = true
 humantime.workspace      = true
+libc.workspace           = true
 reqwest.workspace        = true
 serde.workspace          = true
 serde-saphyr.workspace   = true

--- a/gnosis_vpn-ctl/src/cli.rs
+++ b/gnosis_vpn-ctl/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use gnosis_vpn_lib::command::Command as LibCommand;
+use gnosis_vpn_lib::dirs;
 use gnosis_vpn_lib::socket;
 use std::path::PathBuf;
 
@@ -29,6 +30,14 @@ pub struct Cli {
     /// Output format applied to every command
     #[arg(short = 'o', long = "output", value_name = "FORMAT", value_enum)]
     pub output: Option<OutputFormat>,
+
+    /// Service state directory - practically identical with home directory of the worker user
+    #[arg(
+        long,
+        env = dirs::ENV_VAR_STATE_HOME,
+        default_value = dirs::DEFAULT_STATE_HOME,
+    )]
+    pub state_home: PathBuf,
 }
 
 #[derive(Debug, Subcommand)]
@@ -103,6 +112,13 @@ pub enum Command {
         #[arg(short = 'f', long)]
         force: bool,
     },
+
+    /// Decrypt the HOPR identity and print the derived Gnosis address and private key.
+    ///
+    /// Requires root because the identity file lives in a worker-owned directory.
+    /// When invoked as a non-root user, the command re-execs itself via sudo.
+    #[command()]
+    GetIdentity {},
 }
 
 impl From<Command> for LibCommand {
@@ -121,6 +137,7 @@ impl From<Command> for LibCommand {
             Command::StartClient { keep_alive } => LibCommand::StartClient(keep_alive.into()),
             Command::StopClient {} => LibCommand::StopClient,
             Command::CheckUpdate { .. } => unreachable!("CheckUpdate is handled before socket dispatch"),
+            Command::GetIdentity {} => unreachable!("GetIdentity is handled before socket dispatch"),
         }
     }
 }

--- a/gnosis_vpn-ctl/src/main.rs
+++ b/gnosis_vpn-ctl/src/main.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use gnosis_vpn_lib::check_update;
 use gnosis_vpn_lib::command::{self, Command, Response};
 use gnosis_vpn_lib::connection::destination::{NodeId, RoutingOptions};
+use gnosis_vpn_lib::hopr::identity;
 use gnosis_vpn_lib::socket;
 
 mod cli;
@@ -26,6 +27,11 @@ async fn main() {
 
     if let cli::Command::CheckUpdate { force } = args.command {
         let exit = run_check_update(format, &args.socket_path, force).await;
+        process::exit(exit);
+    }
+
+    if let cli::Command::GetIdentity {} = args.command {
+        let exit = run_get_identity(&args.state_home);
         process::exit(exit);
     }
 
@@ -104,6 +110,64 @@ async fn run_check_update(format: OutputFormat, socket_path: &std::path::Path, f
         }
         Err(e) => emit_check_update_error(format, CheckUpdateErrorKind::Unavailable, &e.to_string()),
     }
+}
+
+fn run_get_identity(state_home: &std::path::Path) -> ExitCode {
+    // The identity file lives in a worker-owned, 0o700 directory, so we must be root.
+    // SAFETY: geteuid is always safe; it cannot fail.
+    if unsafe { libc::geteuid() } != 0 {
+        return reexec_with_sudo();
+    }
+
+    let id_file = gnosis_vpn_lib::hopr::identity::file(state_home.to_path_buf());
+    let pass_file = gnosis_vpn_lib::hopr::identity::pass_file(state_home.to_path_buf());
+
+    let password = match std::fs::read_to_string(&pass_file) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Failed to read identity password file {}: {e}", pass_file.display());
+            return exitcode::NOINPUT;
+        }
+    };
+
+    match identity::get_identity(&id_file, password.trim_end_matches('\n')) {
+        Ok((private_key, address)) => {
+            println!("Gnosis Address: {}", address.to_checksum());
+            println!("Private Key: 0x{}", hex_encode(&private_key));
+            exitcode::OK
+        }
+        Err(e) => {
+            eprintln!("Failed to decrypt identity {}: {e}", id_file.display());
+            exitcode::SOFTWARE
+        }
+    }
+}
+
+fn reexec_with_sudo() -> ExitCode {
+    use std::os::unix::process::CommandExt;
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Failed to determine current executable: {e}");
+            return exitcode::SOFTWARE;
+        }
+    };
+    let mut cmd = std::process::Command::new("sudo");
+    cmd.arg(&exe).args(std::env::args_os().skip(1));
+    // `exec` only returns on failure
+    let err = cmd.exec();
+    eprintln!("Failed to invoke sudo: {err}");
+    exitcode::SOFTWARE
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/gnosis_vpn-lib/src/hopr/identity.rs
+++ b/gnosis_vpn-lib/src/hopr/identity.rs
@@ -1,9 +1,12 @@
+use edgli::hopr_lib::Address;
 use edgli::hopr_lib::exports::crypto::keypair::errors::KeyPairError;
+use edgli::hopr_lib::exports::crypto::types::prelude::Keypair;
 use edgli::hopr_lib::{HoprKeys, IdentityRetrievalModes};
 use rand::distr::Alphanumeric;
 use rand::prelude::*;
 use thiserror::Error;
 
+use std::path::Path;
 use std::path::PathBuf;
 
 use crate::dirs;
@@ -23,13 +26,25 @@ pub enum Error {
     Dirs(#[from] crate::dirs::Error),
 }
 
-pub fn from_path(file: PathBuf, pass: String) -> Result<HoprKeys, Error> {
+pub fn from_path(file: PathBuf, password: String) -> Result<HoprKeys, Error> {
     let id_path = file.to_string_lossy().to_string();
     let retrieval_mode = IdentityRetrievalModes::FromFile {
-        password: pass.as_str(),
+        password: password.as_str(),
         id_path: id_path.as_str(),
     };
     HoprKeys::try_from(retrieval_mode).map_err(Error::KeyPair)
+}
+
+pub fn get_identity(file: &Path, password: &str) -> Result<([u8; 32], Address), Error> {
+    let keys = from_path(file.to_path_buf(), password.to_string())?;
+    let private_key: [u8; 32] = keys
+        .chain_key
+        .secret()
+        .as_ref()
+        .try_into()
+        .expect("chain key secret is 32 bytes");
+    let address = keys.chain_key.public().to_address();
+    Ok((private_key, address))
 }
 
 pub fn file(state_home: PathBuf) -> PathBuf {


### PR DESCRIPTION
Adds a `gnosis_vpn-ctl get-identity` command that prints the private key and derived address