### PR TITLE
chore(deps): bump edgli to 4195ca5 + hopr-utils-session to ef210ce3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,8 +2522,8 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.2.4"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=7e0df7581427ba2ea8597160b0d1b14b4acf8603#7e0df7581427ba2ea8597160b0d1b14b4acf8603"
+version = "3.3.1"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=0750b64fb991443a3f571bc9b06bbf2eba36bcf2#0750b64fb991443a3f571bc9b06bbf2eba36bcf2"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "futures",
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3873,8 +3873,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+version = "0.28.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3915,13 +3915,15 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "futures",
  "futures-timer",
  "hopr-types",
+ "humantime-serde",
  "lazy_static",
  "parking_lot",
+ "serde",
  "smart-default",
  "thiserror 2.0.18",
  "tracing",
@@ -3930,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3949,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3974,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4007,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4074,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4104,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=0750b64fb991443a3f571bc9b06bbf2eba36bcf2#0750b64fb991443a3f571bc9b06bbf2eba36bcf2"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=4195ca5573f6ee4bbf3002c8ecd9d43ce7d6355f#4195ca5573f6ee4bbf3002c8ecd9d43ce7d6355f"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2534,8 +2534,10 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-lib",
- "hopr-reference",
+ "hopr-network-graph",
  "hopr-strategy",
+ "hopr-ticket-manager",
+ "hopr-transport-p2p",
  "lazy_static",
  "mimalloc",
  "opentelemetry",
@@ -3603,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3632,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -3655,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3672,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3702,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3712,6 +3714,8 @@ dependencies = [
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
+ "rand 0.10.1",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3719,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3732,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3762,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3793,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3806,28 +3810,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-reference"
-version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
-dependencies = [
- "anyhow",
- "futures",
- "hopr-api",
- "hopr-chain-connector",
- "hopr-ct-full-network",
- "hopr-lib",
- "hopr-network-graph",
- "hopr-ticket-manager",
- "hopr-transport-p2p",
- "tokio",
- "tracing",
- "validator",
-]
-
-[[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3840,6 +3825,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "moka",
+ "multiaddr",
  "parking_lot",
  "serde",
  "serde_with",
@@ -3851,8 +3837,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+version = "0.5.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3874,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3915,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3932,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3951,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3976,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4009,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4076,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4106,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=46b7a890999bcdcb9442d3b92faeb2d2f5fef019#46b7a890999bcdcb9442d3b92faeb2d2f5fef019"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2#ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "0750b64fb991443a3f571bc9b06bbf2eba36bcf2", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "4195ca5573f6ee4bbf3002c8ecd9d43ce7d6355f", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "46b7a890999bcdcb9442d3b92faeb2d2f5fef019", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "ef210ce3fc2862f2a1cab97ca3656c0e995cc3b2", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "7e0df7581427ba2ea8597160b0d1b14b4acf8603", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "0750b64fb991443a3f571bc9b06bbf2eba36bcf2", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "46b7a890999bcdcb9442d3b92faeb2d2f5fef019", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -144,7 +144,8 @@ path    = { hops = 1 }
 # min_open_channels = 5
 # target number of open outgoing channels
 # target_open_channels = 8
-# restrict channel opening to a fixed set of peers; omit section to select peers by quality score (default)
+# channel allowlist: when enabled, restricts channel opening to the listed peers only.
+# When disabled (default), peers are selected by quality score.
 # [strategy.channel_allowlist]
 # enabled = false
 # peers = ["0x...", "0x..."]

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -144,3 +144,7 @@ path    = { hops = 1 }
 # min_open_channels = 5
 # target number of open outgoing channels
 # target_open_channels = 8
+# restrict channel opening to a fixed set of peers; omit section to select peers by quality score (default)
+# [strategy.channel_allowlist]
+# enabled = false
+# peers = ["0x...", "0x..."]

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -494,8 +494,19 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
         }
         if key == "strategy" {
             if let Some(strategy) = value.as_table() {
-                for (k, _) in strategy.iter() {
+                for (k, v) in strategy.iter() {
                     if k == "desired_message_count" || k == "min_open_channels" || k == "target_open_channels" {
+                        continue;
+                    }
+                    if k == "channel_allowlist" {
+                        if let Some(allowlist) = v.as_table() {
+                            for (k2, _) in allowlist.iter() {
+                                if k2 == "enabled" || k2 == "peers" {
+                                    continue;
+                                }
+                                wrong.push(format!("strategy.channel_allowlist.{k2}"));
+                            }
+                        }
                         continue;
                     }
                     wrong.push(format!("strategy.{k}"));
@@ -508,11 +519,20 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
     wrong
 }
 
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(super) struct ChannelAllowlistConfig {
+    pub(super) enabled: bool,
+    #[serde_as(as = "Vec<DisplayFromStr>")]
+    pub(super) peers: Vec<Address>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(super) struct Strategy {
     pub(super) desired_message_count: Option<u64>,
     pub(super) min_open_channels: Option<usize>,
     pub(super) target_open_channels: Option<usize>,
+    pub(super) channel_allowlist: Option<ChannelAllowlistConfig>,
 }
 
 impl From<Option<Strategy>> for StrategyConfig {
@@ -531,6 +551,10 @@ impl From<Option<Strategy>> for StrategyConfig {
                 .as_ref()
                 .and_then(|s| s.target_open_channels)
                 .unwrap_or(def.target_open_channels),
+            channel_allowlist: v
+                .as_ref()
+                .and_then(|s| s.channel_allowlist.as_ref())
+                .and_then(|c| c.enabled.then(|| c.peers.iter().cloned().collect())),
         }
     }
 }

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -636,8 +636,10 @@ pub fn convert_destinations(
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, convert_destinations};
+    use super::{ChannelAllowlistConfig, Config, Strategy, convert_destinations};
+    use crate::hopr::strategy_config::StrategyConfig;
     use edgli::hopr_lib::HopRouting;
+    use edgli::hopr_lib::api::types::primitive::prelude::Address;
 
     fn parse(toml: &str) -> Config {
         toml::from_str(toml).expect("valid TOML")
@@ -714,5 +716,37 @@ path = { hops = 4 }
 "#####,
         );
         assert!(result.is_err(), "v6 must reject hops > MAX_HOPS");
+    }
+
+    #[test]
+    fn strategy_channel_allowlist_enabled_produces_some() {
+        let addr: Address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739".parse().unwrap();
+        let strategy = Some(Strategy {
+            desired_message_count: None,
+            min_open_channels: None,
+            target_open_channels: None,
+            channel_allowlist: Some(ChannelAllowlistConfig {
+                enabled: true,
+                peers: vec![addr.clone()],
+            }),
+        });
+        let cfg: StrategyConfig = strategy.into();
+        assert_eq!(cfg.channel_allowlist, Some(std::collections::HashSet::from([addr])));
+    }
+
+    #[test]
+    fn strategy_channel_allowlist_disabled_produces_none() {
+        let addr: Address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739".parse().unwrap();
+        let strategy = Some(Strategy {
+            desired_message_count: None,
+            min_open_channels: None,
+            target_open_channels: None,
+            channel_allowlist: Some(ChannelAllowlistConfig {
+                enabled: false,
+                peers: vec![addr],
+            }),
+        });
+        let cfg: StrategyConfig = strategy.into();
+        assert!(cfg.channel_allowlist.is_none());
     }
 }

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -393,6 +393,7 @@ async fn run_minimum_balance_recommendation(
     tracing::debug!("starting minimum balance recommendation runner");
     (|| {
         let ops = incentive_operations.clone();
+        let cfg = cfg.clone();
         async move {
             let rec = edgli::strategy::minimum_balance_recommendation(&*ops, &cfg)
                 .await

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -322,7 +322,7 @@ impl Hopr {
         &self,
         sizing: edgli::strategy::IncentiveConfiguration,
     ) -> Result<AbortHandle, HoprError> {
-        let cfg = edgli::strategy::default_strategy_cfg(&self.edgli, sizing)
+        let cfg = edgli::strategy::default_strategy_cfg(&self.edgli, &sizing)
             .await
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))?;
         self.edgli

--- a/gnosis_vpn-lib/src/hopr/strategy_config.rs
+++ b/gnosis_vpn-lib/src/hopr/strategy_config.rs
@@ -37,6 +37,7 @@ impl From<StrategyConfig> for edgli::strategy::IncentiveConfiguration {
             desired_message_count: c.desired_message_count,
             min_open_channels: c.min_open_channels,
             target_open_channels: c.target_open_channels,
+            channel_allowlist: None,
         }
     }
 }

--- a/gnosis_vpn-lib/src/hopr/strategy_config.rs
+++ b/gnosis_vpn-lib/src/hopr/strategy_config.rs
@@ -1,11 +1,13 @@
+use std::collections::HashSet;
+
+use edgli::hopr_lib::api::types::primitive::prelude::Address;
 use serde::{Deserialize, Serialize};
 
-/// Sizing and topology parameters for the channel lifecycle strategy reactor.
+/// Operator-tunable parameters for the channel lifecycle strategy reactor.
 ///
-/// Maps 1-to-1 to [`edgli::strategy::IncentiveConfiguration`]; carried in the gnosis_vpn
-/// config layer so operators can tune channel funding from the TOML config file.
-///
-/// All fields default to the same values as [`edgli::strategy::IncentiveConfiguration`].
+/// Exposes the subset of [`edgli::strategy::IncentiveConfiguration`] that operators
+/// can tune via the TOML config file. Fields not listed here fall back to upstream
+/// defaults (see [`edgli::strategy::IncentiveConfiguration::default`]).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StrategyConfig {
     /// Expected number of mixnet messages per channel before exhaustion.
@@ -18,6 +20,9 @@ pub struct StrategyConfig {
 
     /// Target number of open outgoing channels.
     pub target_open_channels: usize,
+
+    /// When `Some`, channels are opened exclusively to these peers; `None` uses quality-score selection.
+    pub channel_allowlist: Option<HashSet<Address>>,
 }
 
 impl Default for StrategyConfig {
@@ -27,6 +32,7 @@ impl Default for StrategyConfig {
             desired_message_count: def.desired_message_count,
             min_open_channels: def.min_open_channels,
             target_open_channels: def.target_open_channels,
+            channel_allowlist: def.channel_allowlist,
         }
     }
 }
@@ -37,7 +43,7 @@ impl From<StrategyConfig> for edgli::strategy::IncentiveConfiguration {
             desired_message_count: c.desired_message_count,
             min_open_channels: c.min_open_channels,
             target_open_channels: c.target_open_channels,
-            channel_allowlist: None,
+            channel_allowlist: c.channel_allowlist,
         }
     }
 }


### PR DESCRIPTION
## Summary

Depends on: https://github.com/hoprnet/edge-client/pull/85

- **edgli**: `0750b64` → `4195ca5` (edge-client, branch `kauki/chore/deps/bump-hoprnet-rev-46b7a89099`) — picks up edge-client PR hoprnet/edge-client#85 which bumps the hoprnet rev to `ef210ce3`
- **hopr-utils-session**: `46b7a890` → `ef210ce3` (hoprnet/hoprnet#8178)

**hopr-utils-session change** (hoprnet/hoprnet#8178): `hopr-ticket-manager` bumped from v0.4.0 to v0.5.0 — 20 hoprnet crates updated to new rev.