### PR TITLE
chore(deps): bump edgli + hoprnet to HOL-blocking fix (edge-client#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=eabf2b45324c29ab420c7c993bd7721814515e1c#eabf2b45324c29ab420c7c993bd7721814515e1c"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=b6c52fb1a836be8c1034d3001a24437824eb06d4#b6c52fb1a836be8c1034d3001a24437824eb06d4"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3601,8 +3601,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+version = "0.21.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3764,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3857,17 +3857,17 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.30.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+version = "0.31.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
- "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
  "cfg-if",
  "dashmap",
+ "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -3899,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3992,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=c18f956e7d59450e81a002e39d464502c17b5c86#c18f956e7d59450e81a002e39d464502c17b5c86"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=eabf2b45324c29ab420c7c993bd7721814515e1c#eabf2b45324c29ab420c7c993bd7721814515e1c"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3764,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3858,10 +3858,11 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.30.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "ahash",
  "anyhow",
+ "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
@@ -3898,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3915,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3935,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3960,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3991,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4059,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4089,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bcb8a2c9f28e53f91d958ce8d393baaafa74be4d#bcb8a2c9f28e53f91d958ce8d393baaafa74be4d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossfire"
+version = "3.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+dependencies = [
+ "crossbeam-utils",
+ "embed-collections",
+ "futures-core",
+ "parking_lot",
+ "smallvec",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=e33f924ccf144e4e3695cd78458a077bb8d4fe9a#e33f924ccf144e4e3695cd78458a077bb8d4fe9a"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=556365f7b544a25b78ec22cce31bef026993901b#556365f7b544a25b78ec22cce31bef026993901b"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2595,6 +2608,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embed-collections"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "embedded-io"
@@ -3602,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3632,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "bimap",
  "const-hex",
@@ -3655,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3672,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3702,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3721,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3734,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3764,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3795,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3810,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3836,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3858,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.31.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3866,8 +3885,8 @@ dependencies = [
  "async_channel_io",
  "bytes",
  "cfg-if",
+ "crossfire",
  "dashmap",
- "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -3899,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3915,8 +3934,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+version = "0.9.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3929,6 +3948,7 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "pin-project",
+ "quinn-udp",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3936,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3992,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4060,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4090,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=b6c52fb1a836be8c1034d3001a24437824eb06d4#b6c52fb1a836be8c1034d3001a24437824eb06d4"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=e33f924ccf144e4e3695cd78458a077bb8d4fe9a#e33f924ccf144e4e3695cd78458a077bb8d4fe9a"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1271,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -2268,6 +2319,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=625965d1438e795fca6a7b49d3d2220b5026de8f#625965d1438e795fca6a7b49d3d2220b5026de8f"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=c18f956e7d59450e81a002e39d464502c17b5c86#c18f956e7d59450e81a002e39d464502c17b5c86"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2658,6 +2723,18 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.4",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -2907,6 +2984,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3370,8 +3458,10 @@ dependencies = [
  "once_cell",
  "rand 0.9.4",
  "ring",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -3413,6 +3503,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -3987,7 +4078,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
- "socket2",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4162,7 +4253,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4338,7 +4429,29 @@ dependencies = [
  "netlink-sys",
  "rtnetlink",
  "system-configuration",
+ "tokio",
  "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -4472,7 +4585,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -4755,11 +4868,14 @@ dependencies = [
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
+ "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-quic",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
+ "libp2p-upnp",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -4896,6 +5012,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-mdns"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+dependencies = [
+ "futures",
+ "hickory-proto 0.25.2",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.6",
+ "smallvec",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,6 +5067,29 @@ dependencies = [
  "tracing",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.6",
+ "ring",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4982,6 +5140,7 @@ dependencies = [
  "multistream-select",
  "rand 0.8.6",
  "smallvec",
+ "tokio",
  "tracing",
  "web-time",
 ]
@@ -5008,7 +5167,42 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2",
+ "socket2 0.6.4",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-webpki",
+ "thiserror 2.0.18",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
  "tracing",
 ]
 
@@ -5165,6 +5359,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -5392,6 +5592,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5545,6 +5755,15 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -5797,6 +6016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5896,7 +6125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "044b1fa4f259f4df9ad5078e587b208f5d288a25407575fcddb9face30c7c692"
 dependencies = [
  "rand 0.9.4",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
 ]
 
@@ -6215,12 +6444,13 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6235,6 +6465,7 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
@@ -6258,7 +6489,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6405,6 +6636,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -6663,6 +6907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6684,6 +6937,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7309,6 +7563,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -7654,7 +7918,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7869,6 +8133,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8752,6 +9017,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
 name = "yamux"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8787,6 +9084,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -516,7 +516,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -734,7 +734,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c49aad21c0d9dac90f52c45894e7f23a7201d0264c07a4546c1df603ca3158"
+checksum = "4ecdfbd15f4ff885b4aaea1630d1e318f15462c85971b0bb3150b228b7792d60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1472,7 +1472,7 @@ dependencies = [
  "hopr-types",
  "http",
  "launchdarkly-sdk-transport",
- "reqwest 0.12.28",
+ "reqwest",
  "semver 1.0.28",
  "serde_json",
  "smart-default",
@@ -1681,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2100,7 +2100,7 @@ checksum = "f2e722e1560ed4e4260cf35ac5fafc422aa7682c919db5a14209e4afad4446c2"
 dependencies = [
  "cynic-proc-macros",
  "ref-cast",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "static_assertions",
@@ -2457,8 +2457,8 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.3.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=12769bc78a2ef66ea92f7b1439ffe3edcf824ab2#12769bc78a2ef66ea92f7b1439ffe3edcf824ab2"
+version = "3.3.1"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=625965d1438e795fca6a7b49d3d2220b5026de8f#625965d1438e795fca6a7b49d3d2220b5026de8f"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2638,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4199ae8c124383f00a7af9df684a878186c8081c6c8bf2cac8c29296db3625d"
+checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
  "base64",
  "bytes",
@@ -2783,21 +2783,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3093,7 +3078,7 @@ dependencies = [
  "exitcode",
  "gnosis_vpn-lib",
  "humantime",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -3126,7 +3111,7 @@ dependencies = [
  "pfctl",
  "ping",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -3178,7 +3163,7 @@ dependencies = [
  "exitcode",
  "gnosis_vpn-lib",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3486,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33fb0c32d216e93e58a050edea339bc8ed5bd8fe844bf893b849fc402824412"
+checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3525,8 +3510,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.21.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3550,19 +3535,20 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-crypto-packet"
-version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "1.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "bimap",
+ "const-hex",
  "curve25519-dalek",
  "elliptic-curve",
  "flagset",
  "generic-array 1.4.3",
- "hex",
  "hopr-types",
  "hopr-utils",
  "k256",
@@ -3578,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3594,8 +3580,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "4.0.2-rc.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3625,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -3635,6 +3621,8 @@ dependencies = [
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
+ "rand 0.10.1",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3642,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -3654,8 +3642,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "4.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3663,7 +3651,7 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "cfg_eval",
- "hex",
+ "const-hex",
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
@@ -3685,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -3716,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -3731,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3744,6 +3732,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "moka",
+ "multiaddr",
  "parking_lot",
  "serde",
  "serde_with",
@@ -3756,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3777,8 +3766,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.30.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3794,7 +3783,6 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
- "hopr-ticket-manager",
  "hopr-transport-mixer",
  "hopr-transport-probe",
  "hopr-transport-session",
@@ -3819,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3835,8 +3823,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.9.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -3848,20 +3836,21 @@ dependencies = [
  "libp2p",
  "libp2p-stream",
  "multiaddr",
+ "pin-project",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+version = "0.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
+ "const-hex",
  "futures",
  "futures-concurrency",
- "hex",
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
@@ -3880,10 +3869,9 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
- "arrayvec",
  "async-trait",
  "flagset",
  "futures",
@@ -3893,7 +3881,6 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-transport-tag-allocator",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3913,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -3924,26 +3911,27 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e82a6426de74cdef7bbef15f651ce546ab39fc77ef1dc4002247b6bbf034fc"
+checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "arrayvec",
  "async-trait",
  "bigdecimal",
  "blake3",
  "chacha20 0.9.1",
  "chrono",
  "cipher 0.4.4",
+ "const-hex",
  "ctr",
  "curve25519-dalek",
  "digest 0.10.7",
  "ed25519-dalek",
  "float-cmp",
  "generic-array 1.4.3",
- "hex",
  "hex-literal",
  "hopr-bindings",
  "k256",
@@ -3980,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4010,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e#1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4036,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -4154,22 +4142,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4722,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-sdk-transport"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48629e54c0e45cb102a333271f363eb521e7785d54e5047a5d1c6f2770c765"
+checksum = "a048341aa360a768a7d91ebf6232a574f355ada0724acff2df7c5d8dc1e04c98"
 dependencies = [
  "bytes",
  "futures",
@@ -5102,7 +5074,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
  "syn 2.0.117",
 ]
 
@@ -5309,23 +5281,6 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -5615,47 +5570,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -5695,7 +5613,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry 0.32.0",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -5710,7 +5628,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk 0.32.1",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -6223,7 +6141,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6529,14 +6447,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -6547,7 +6465,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -6558,52 +6476,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -6638,12 +6513,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7197,22 +7074,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -7230,9 +7095,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7807,16 +7672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8215,9 +8070,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8270,12 +8125,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -8414,9 +8263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "12769bc78a2ef66ea92f7b1439ffe3edcf824ab2", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "625965d1438e795fca6a7b49d3d2220b5026de8f", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "261641b759accabeb77aba917d2067a2cd69c837", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "b6c52fb1a836be8c1034d3001a24437824eb06d4", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "b6c52fb1a836be8c1034d3001a24437824eb06d4", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "e33f924ccf144e4e3695cd78458a077bb8d4fe9a", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "eabf2b45324c29ab420c7c993bd7721814515e1c", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "261641b759accabeb77aba917d2067a2cd69c837", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "c18f956e7d59450e81a002e39d464502c17b5c86", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "eabf2b45324c29ab420c7c993bd7721814515e1c", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "1765e5c48e9dbfcccc5b411bf59bee5ca65efc4e", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "bcb8a2c9f28e53f91d958ce8d393baaafa74be4d", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "625965d1438e795fca6a7b49d3d2220b5026de8f", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "c18f956e7d59450e81a002e39d464502c17b5c86", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ chrono = { version = "0.4.38", default-features = false, features = [
 cidr = "0.3.2"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 clap_complete = "4"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "e33f924ccf144e4e3695cd78458a077bb8d4fe9a", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "556365f7b544a25b78ec22cce31bef026993901b", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "1.1.2"
 futures = "0.3.31"
 futures-util = "0.3.31"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "0.1.4"

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -1,5 +1,6 @@
 use edgli::EdgliInitState;
 use edgli::blokli::IncentiveOperations;
+use edgli::hopr_lib::api::types::primitive::traits::ToHex;
 use edgli::hopr_lib::builder::Keypair;
 use edgli::hopr_lib::exports::transport::SessionId;
 use futures_util::future::AbortHandle;
@@ -11,7 +12,6 @@ use tokio_util::task::TaskTracker;
 
 use std::collections::{HashMap, HashSet};
 use std::net;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -1687,9 +1687,9 @@ impl Core {
         // Cache the pseudonym so a reconnect within the TTL window can reuse exit node SURBs.
         if let Some((_, session)) = &conn.active_session
             && let Some(client_id) = session.active_clients.first()
-            && let Ok(session_id) = SessionId::from_str(client_id)
+            && let Ok(session_id) = SessionId::from_hex(client_id)
         {
-            self.pseudonym_cache.insert(&conn.destination, *session_id.pseudonym());
+            self.pseudonym_cache.insert(&conn.destination, session_id);
         }
         self.cancel_connection.cancel();
         self.cancel_connection = self.cancel_on_shutdown.child_token();

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -1687,9 +1687,9 @@ impl Core {
         // Cache the pseudonym so a reconnect within the TTL window can reuse exit node SURBs.
         if let Some((_, session)) = &conn.active_session
             && let Some(client_id) = session.active_clients.first()
-            && let Ok(session_id) = SessionId::from_hex(client_id)
+            && let Ok(pseudonym) = SessionId::from_hex(client_id)
         {
-            self.pseudonym_cache.insert(&conn.destination, session_id);
+            self.pseudonym_cache.insert(&conn.destination, pseudonym);
         }
         self.cancel_connection.cancel();
         self.cancel_connection = self.cancel_on_shutdown.child_token();

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -7,7 +7,10 @@ use edgli::{
         api::{
             chain::ChainKeyOperations,
             node::{HasChainApi, HasTransportApi},
-            types::{internal::channels::ChannelStatus, primitive::prelude::Address},
+            types::{
+                internal::channels::ChannelStatus,
+                primitive::{prelude::Address, traits::ToHex},
+            },
         },
         exports::{
             network::types::types::IpProtocol,
@@ -25,7 +28,6 @@ use tokio::task::JoinSet;
 use tracing::instrument;
 
 use std::collections::{BTreeSet, HashMap};
-use std::str::FromStr;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
@@ -256,7 +258,7 @@ impl Hopr {
     #[tracing::instrument(skip(self), level = "debug", ret)]
     pub async fn adjust_session(&self, balancer_cfg: SurbBalancerConfig, client: String) -> Result<(), HoprError> {
         tracing::debug!("adjust hopr session");
-        let session_id = SessionId::from_str(&client).map_err(|e| HoprError::SessionNotAdjusted(e.to_string()))?;
+        let session_id = SessionId::from_hex(&client).map_err(|e| HoprError::SessionNotAdjusted(e.to_string()))?;
 
         // NOTE: the live SURB balancer is updated via the configurator below, but the
         // cached `max_surb_upstream` and `response_buffer` snapshots stored in


### PR DESCRIPTION
## Summary

- Bumps `edgli` (edge-client) to [`556365f`](https://github.com/hoprnet/edge-client/pull/85) (merged edge-client PR #85)
- Bumps `hopr-utils-session` (hoprnet) to [`d670a6c`](https://github.com/hoprnet/hoprnet/pull/8204) (hoprnet master tip, hoprnet#8204: non-blocking flume drop-oldest ring buffer for per-peer egress)
- The hoprnet#8204 change fixes the `for_each_concurrent(30)` slot exhaustion caused by unreachable relay peers blocking the egress pipeline
- Edge-client PR #85 also re-exports `PathPlannerConfig` at the `edgli` crate root so consumers can tune `cfg.protocol.path_planner.latency_halflife` before calling `Edgli::new()` without a direct hoprnet dependency
- Renames `session_id` → `pseudonym` in the `pseudonym_cache` insert site (`SessionId` is a type alias for `HoprPseudonym` so insertion compiles, but the rename makes the intent clear)

Depends on: https://github.com/hoprnet/edge-client/pull/85