### PR TITLE
test(lib): add socket_types integration test and fix missing public e…

### DIFF
--- a/gnosis_vpn-lib/src/command/balance_response.rs
+++ b/gnosis_vpn-lib/src/command/balance_response.rs
@@ -5,7 +5,8 @@ use std::{
     fmt::{self, Display},
 };
 
-use crate::{balance, connection::destination::Destination, info::Info, serde_utils};
+use crate::{balance, connection::destination::Destination, serde_utils};
+pub use crate::info::Info;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ChannelOut {

--- a/gnosis_vpn-lib/src/command/balance_response.rs
+++ b/gnosis_vpn-lib/src/command/balance_response.rs
@@ -5,8 +5,8 @@ use std::{
     fmt::{self, Display},
 };
 
-use crate::{balance, connection::destination::Destination, serde_utils};
 pub use crate::info::Info;
+use crate::{balance, connection::destination::Destination, serde_utils};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ChannelOut {

--- a/gnosis_vpn-lib/src/command/mod.rs
+++ b/gnosis_vpn-lib/src/command/mod.rs
@@ -15,10 +15,10 @@ use crate::connection::destination::{Address, Destination};
 use crate::log_output;
 use crate::route_health::{RouteHealth, RouteHealthState};
 use crate::serde_utils;
-use crate::ticket_stats::TicketStats;
+pub use crate::ticket_stats::TicketStats;
 
 mod balance_response;
-pub use balance_response::{BalanceResponse, ChannelBalance, ChannelOut};
+pub use balance_response::{BalanceResponse, ChannelBalance, ChannelOut, Info};
 
 /// These commands are sent by the ctl app and forwarded to the core loop for answering
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/gnosis_vpn-lib/src/connection/mod.rs
+++ b/gnosis_vpn-lib/src/connection/mod.rs
@@ -1,5 +1,5 @@
 pub mod destination;
-pub(crate) mod down;
+pub mod down;
 pub(crate) mod options;
 pub(crate) mod pseudonym_cache;
-pub(crate) mod up;
+pub mod up;

--- a/gnosis_vpn-lib/src/connection/mod.rs
+++ b/gnosis_vpn-lib/src/connection/mod.rs
@@ -1,5 +1,8 @@
 pub mod destination;
-pub mod down;
+pub(crate) mod down;
 pub(crate) mod options;
 pub(crate) mod pseudonym_cache;
-pub mod up;
+pub(crate) mod up;
+
+pub use down::Phase as DownPhase;
+pub use up::Phase as UpPhase;

--- a/gnosis_vpn-lib/src/route_health.rs
+++ b/gnosis_vpn-lib/src/route_health.rs
@@ -41,6 +41,8 @@ use crate::hopr::{Hopr, HoprError};
 use crate::serde_utils;
 use crate::{gvpn_client, log_output};
 
+pub use crate::gvpn_client::{Health, LoadAvg, Slots, Versions};
+
 const MAX_INTERVAL_BETWEEN_FAILURES: Duration = Duration::from_mins(5);
 const FAILURE_INTERVAL: Duration = Duration::from_secs(30);
 /// Retry interval for the first few health-check failures while the HOPR

--- a/gnosis_vpn-lib/tests/socket_types.rs
+++ b/gnosis_vpn-lib/tests/socket_types.rs
@@ -1,0 +1,73 @@
+//! Integration test: every type that appears in the socket API surface must be
+//! reachable from outside the crate. This file is compiled as a separate crate,
+//! so any type that can't be named here isn't properly exported.
+//! Compilation failure == missing export.
+
+use gnosis_vpn_lib::balance::{BalanceRecommendation, CapacityAllocator, CapacityEntry, Capacity, FundingIssue};
+use gnosis_vpn_lib::command::{
+    ActiveSession, BalanceResponse, ChannelBalance, ChannelOut, Command, ConnStats, ConnectResponse,
+    ConnectingInfo, ConnectedInfo, DestinationState, DisconnectResponse, DisconnectingInfo,
+    FundingToolResponse, HoprInitStatus, HoprStatus, Info, InfoResponse, NerdStatsResponse,
+    ReconnectingInfo, Response, RouteHealthView, RunMode, StartClientResponse, StopClientResponse,
+    StatusResponse, TicketStats, TicketStatsStatus, WorkerCommand,
+};
+use gnosis_vpn_lib::connection::destination::{Address, Destination, HopRouting};
+use gnosis_vpn_lib::connection::down::Phase as DownPhase;
+use gnosis_vpn_lib::connection::up::Phase as UpPhase;
+use gnosis_vpn_lib::route_health::{
+    ExitHealth, Health, LoadAvg, RouteHealthState, Slots, UnrecoverableReason, Versions,
+};
+
+// This function exists only to force the compiler to verify that every type in
+// the socket API surface is reachable from outside the crate. It is never called.
+#[allow(dead_code)]
+fn assert_types_are_accessible() {
+    let _: Command;
+    let _: WorkerCommand;
+    let _: Response;
+    let _: StatusResponse;
+    let _: ConnectingInfo;
+    let _: ReconnectingInfo;
+    let _: ConnectedInfo;
+    let _: DisconnectingInfo;
+    let _: DestinationState;
+    let _: RunMode;
+    let _: HoprStatus;
+    let _: HoprInitStatus;
+    let _: InfoResponse;
+    let _: StartClientResponse;
+    let _: StopClientResponse;
+    let _: ConnectResponse;
+    let _: DisconnectResponse;
+    let _: FundingToolResponse;
+    let _: RouteHealthView;
+    let _: TicketStatsStatus;
+    let _: TicketStats;
+    let _: NerdStatsResponse;
+    let _: ConnStats;
+    let _: ActiveSession;
+    let _: BalanceResponse;
+    let _: ChannelOut;
+    let _: ChannelBalance;
+    let _: Info;
+    let _: Destination;
+    let _: Address;
+    let _: HopRouting;
+    let _: UpPhase;
+    let _: DownPhase;
+    let _: RouteHealthState;
+    let _: UnrecoverableReason;
+    let _: ExitHealth;
+    let _: Versions;
+    let _: Health;
+    let _: Slots;
+    let _: LoadAvg;
+    let _: BalanceRecommendation;
+    let _: FundingIssue;
+    let _: CapacityEntry;
+    let _: CapacityAllocator;
+    let _: Capacity;
+}
+
+#[test]
+fn socket_types_compile() {}

--- a/gnosis_vpn-lib/tests/socket_types.rs
+++ b/gnosis_vpn-lib/tests/socket_types.rs
@@ -3,13 +3,12 @@
 //! so any type that can't be named here isn't properly exported.
 //! Compilation failure == missing export.
 
-use gnosis_vpn_lib::balance::{BalanceRecommendation, CapacityAllocator, CapacityEntry, Capacity, FundingIssue};
+use gnosis_vpn_lib::balance::{BalanceRecommendation, Capacity, CapacityAllocator, CapacityEntry, FundingIssue};
 use gnosis_vpn_lib::command::{
-    ActiveSession, BalanceResponse, ChannelBalance, ChannelOut, Command, ConnStats, ConnectResponse,
-    ConnectingInfo, ConnectedInfo, DestinationState, DisconnectResponse, DisconnectingInfo,
-    FundingToolResponse, HoprInitStatus, HoprStatus, Info, InfoResponse, NerdStatsResponse,
-    ReconnectingInfo, Response, RouteHealthView, RunMode, StartClientResponse, StopClientResponse,
-    StatusResponse, TicketStats, TicketStatsStatus, WorkerCommand,
+    ActiveSession, BalanceResponse, ChannelBalance, ChannelOut, Command, ConnStats, ConnectResponse, ConnectedInfo,
+    ConnectingInfo, DestinationState, DisconnectResponse, DisconnectingInfo, FundingToolResponse, HoprInitStatus,
+    HoprStatus, Info, InfoResponse, NerdStatsResponse, ReconnectingInfo, Response, RouteHealthView, RunMode,
+    StartClientResponse, StatusResponse, StopClientResponse, TicketStats, TicketStatsStatus, WorkerCommand,
 };
 use gnosis_vpn_lib::connection::destination::{Address, Destination, HopRouting};
 use gnosis_vpn_lib::connection::{DownPhase, UpPhase};

--- a/gnosis_vpn-lib/tests/socket_types.rs
+++ b/gnosis_vpn-lib/tests/socket_types.rs
@@ -12,8 +12,7 @@ use gnosis_vpn_lib::command::{
     StatusResponse, TicketStats, TicketStatsStatus, WorkerCommand,
 };
 use gnosis_vpn_lib::connection::destination::{Address, Destination, HopRouting};
-use gnosis_vpn_lib::connection::down::Phase as DownPhase;
-use gnosis_vpn_lib::connection::up::Phase as UpPhase;
+use gnosis_vpn_lib::connection::{DownPhase, UpPhase};
 use gnosis_vpn_lib::route_health::{
     ExitHealth, Health, LoadAvg, RouteHealthState, Slots, UnrecoverableReason, Versions,
 };


### PR DESCRIPTION
…xports

Ensures all leaf types reachable via Command/Response are nameable from outside the crate. Fixes: connection::{up,down}::Phase, TicketStats, Info, and gvpn_client::{Versions,Health,Slots,LoadAvg}.