### PR TITLE
feat(hopr): always prefer low-latency path planning and channel opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aquamarine"
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=556365f7b544a25b78ec22cce31bef026993901b#556365f7b544a25b78ec22cce31bef026993901b"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=7da0fa5c713a5e904748802630bdafcf35f651b4#7da0fa5c713a5e904748802630bdafcf35f651b4"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-ctl"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-lib"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-root"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-system_tests"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-worker"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-ctl"
-version = "0.92.0"
+version = "0.91.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-lib"
-version = "0.92.0"
+version = "0.91.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-root"
-version = "0.92.0"
+version = "0.91.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-system_tests"
-version = "0.92.0"
+version = "0.91.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-worker"
-version = "0.92.0"
+version = "0.91.1"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "LGPL-3.0"
-version = "0.92.0"
+version = "0.91.1"
 
 [workspace.metadata.crane]
 name = "gnosis_vpn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "LGPL-3.0"
-version = "0.91.1"
+version = "0.92.0"
 
 [workspace.metadata.crane]
 name = "gnosis_vpn"
@@ -23,7 +23,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.1", features = ["derive", "env"] }
 clap_complete = "~4.6.5"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "556365f7b544a25b78ec22cce31bef026993901b", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "7da0fa5c713a5e904748802630bdafcf35f651b4", features = [
   "blokli",
   "telemetry",
 ] }

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -56,6 +56,11 @@ path    = { hops = 1 }
 # disabled) until hopr-lib supports PIX; set to "30s" once that lands.
 # session_pseudonym_ttl = "30s"
 
+# path_planner_min_ack_rate - minimum acknowledgement rate [0.0, 1.0] a path must
+# sustain to be considered by the latency path planner. Paths below this threshold are
+# skipped. Lower values accept noisier paths; higher values are more selective.
+# path_planner_min_ack_rate = 0.1
+
 # determine specific connection parameters for ephemeral bridge connection
 # [connection.bridge]
 # capabilities = [ "segmentation", "retransmission", "retransmission_ack_only", "no_rate_control" ]

--- a/flake.nix
+++ b/flake.nix
@@ -163,22 +163,20 @@
               inherit pre-commit-check;
               checks = self.checks.${system};
 
-              packages =
-                [
-                  pkgs.cargo-machete
-                  pkgs.cargo-shear
-                  pkgs.just
-                  pkgs.rust-analyzer
-                ]
-                ++ lib.optionals pkgs.stdenv.isLinux [
-                  # Native gnu libs so mnl-sys/nftnl-sys build scripts can fall
-                  # through to pkg-config and link against the host ABI.
-                  # (pkgsStatic variants are musl and break gnu dev builds.)
-                  pkgs.libmnl
-                  pkgs.libnftnl
-                ];
+              packages = [
+                pkgs.cargo-machete
+                pkgs.cargo-shear
+                pkgs.just
+                pkgs.rust-analyzer
+              ];
 
               VERGEN_GIT_SHA = toString (self.shortRev or self.dirtyShortRev);
+            }
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              # Point mnl-sys and nftnl-sys directly to static library dirs,
+              # bypassing pkg-config which can fail in cross-compilation contexts
+              LIBMNL_LIB_DIR = "${pkgs.pkgsStatic.libmnl}/lib";
+              LIBNFTNL_LIB_DIR = "${pkgs.pkgsStatic.libnftnl}/lib";
             }
           );
 

--- a/flake.nix
+++ b/flake.nix
@@ -163,20 +163,22 @@
               inherit pre-commit-check;
               checks = self.checks.${system};
 
-              packages = [
-                pkgs.cargo-machete
-                pkgs.cargo-shear
-                pkgs.just
-                pkgs.rust-analyzer
-              ];
+              packages =
+                [
+                  pkgs.cargo-machete
+                  pkgs.cargo-shear
+                  pkgs.just
+                  pkgs.rust-analyzer
+                ]
+                ++ lib.optionals pkgs.stdenv.isLinux [
+                  # Native gnu libs so mnl-sys/nftnl-sys build scripts can fall
+                  # through to pkg-config and link against the host ABI.
+                  # (pkgsStatic variants are musl and break gnu dev builds.)
+                  pkgs.libmnl
+                  pkgs.libnftnl
+                ];
 
               VERGEN_GIT_SHA = toString (self.shortRev or self.dirtyShortRev);
-            }
-            // lib.optionalAttrs pkgs.stdenv.isLinux {
-              # Point mnl-sys and nftnl-sys directly to static library dirs,
-              # bypassing pkg-config which can fail in cross-compilation contexts
-              LIBMNL_LIB_DIR = "${pkgs.pkgsStatic.libmnl}/lib";
-              LIBNFTNL_LIB_DIR = "${pkgs.pkgsStatic.libnftnl}/lib";
             }
           );
 

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -190,6 +190,7 @@ impl From<Option<Connection>> for options::Options {
             lan_lockdown: false,
             // 1s effectively disables pseudonym caching; revert once hopr-lib supports PIX
             session_pseudonym_ttl: Duration::from_secs(1),
+            path_planner_min_ack_rate: options::DEFAULT_PATH_PLANNER_MIN_ACK_RATE,
         }
     }
 }

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -42,6 +42,7 @@ pub(super) struct Connection {
     pub(super) lan_lockdown: Option<bool>,
     #[serde(default, with = "humantime_serde::option")]
     pub(super) session_pseudonym_ttl: Option<Duration>,
+    #[serde(default, deserialize_with = "validate_path_planner_min_ack_rate")]
     pub(super) path_planner_min_ack_rate: Option<f64>,
 }
 
@@ -133,6 +134,19 @@ pub(super) struct BlokliConfig {
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
+
+fn validate_path_planner_min_ack_rate<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(deserializer)?;
+    match value {
+        Some(v) if !(0.0..=1.0).contains(&v) => Err(serde::de::Error::custom(
+            "path_planner_min_ack_rate must be in the range [0.0, 1.0]",
+        )),
+        other => Ok(other),
+    }
+}
 
 fn validate_n_pings<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
 where
@@ -752,6 +766,25 @@ path_planner_min_ack_rate = 0.5
         );
         let result: crate::config::Config = cfg.try_into().expect("should succeed");
         assert_eq!(result.connection.path_planner_min_ack_rate, 0.5);
+    }
+
+    #[test]
+    fn path_planner_min_ack_rate_rejects_out_of_range() {
+        for bad in &[-0.1_f64, 1.1, 2.0, -1.0] {
+            let toml = format!(
+                r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+
+[connection]
+path_planner_min_ack_rate = {bad}
+"#####
+            );
+            let result = toml::from_str::<Config>(&toml);
+            assert!(result.is_err(), "expected rejection for path_planner_min_ack_rate = {bad}");
+        }
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -783,7 +783,10 @@ path_planner_min_ack_rate = {bad}
 "#####
             );
             let result = toml::from_str::<Config>(&toml);
-            assert!(result.is_err(), "expected rejection for path_planner_min_ack_rate = {bad}");
+            assert!(
+                result.is_err(),
+                "expected rejection for path_planner_min_ack_rate = {bad}"
+            );
         }
     }
 

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -42,6 +42,7 @@ pub(super) struct Connection {
     pub(super) lan_lockdown: Option<bool>,
     #[serde(default, with = "humantime_serde::option")]
     pub(super) session_pseudonym_ttl: Option<Duration>,
+    pub(super) path_planner_min_ack_rate: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -316,6 +317,9 @@ impl From<Option<Connection>> for options::Options {
             health_check_intervals,
             lan_lockdown: connection.and_then(|c| c.lan_lockdown).unwrap_or(false),
             session_pseudonym_ttl,
+            path_planner_min_ack_rate: connection
+                .and_then(|c| c.path_planner_min_ack_rate)
+                .unwrap_or(options::DEFAULT_PATH_PLANNER_MIN_ACK_RATE),
         }
     }
 }
@@ -406,6 +410,7 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
                         || k == "announced_peer_minimum_score"
                         || k == "lan_lockdown"
                         || k == "session_pseudonym_ttl"
+                        || k == "path_planner_min_ack_rate"
                     {
                         continue;
                     }
@@ -716,6 +721,37 @@ path = { hops = 4 }
 "#####,
         );
         assert!(result.is_err(), "v6 must reject hops > MAX_HOPS");
+    }
+
+    #[test]
+    fn path_planner_min_ack_rate_defaults_to_point_one() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+"#####,
+        );
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        assert_eq!(result.connection.path_planner_min_ack_rate, 0.1);
+    }
+
+    #[test]
+    fn path_planner_min_ack_rate_reads_from_connection() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+
+[connection]
+path_planner_min_ack_rate = 0.5
+"#####,
+        );
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        assert_eq!(result.connection.path_planner_min_ack_rate, 0.5);
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -1,3 +1,5 @@
+pub const DEFAULT_PATH_PLANNER_MIN_ACK_RATE: f64 = 0.1;
+
 use bytesize::ByteSize;
 use edgli::hopr_lib::exports::transport::{SessionCapabilities, SessionTarget, SurbBalancerConfig};
 use human_bandwidth::re::bandwidth::Bandwidth;
@@ -21,6 +23,9 @@ pub struct Options {
     /// avoids a cold-start SURB exchange. Currently set to 1s (effectively disabled)
     /// until hopr-lib supports PIX.
     pub session_pseudonym_ttl: Duration,
+    /// Minimum acknowledgement rate [0.0, 1.0] a path must sustain to be considered by
+    /// the latency path planner. Paths below this threshold are skipped.
+    pub path_planner_min_ack_rate: f64,
 }
 
 /// Controls how often each tier of health check runs.

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -1403,12 +1403,13 @@ impl Core {
         let cancel = self.cancel_on_shutdown.clone();
         let worker_params = self.worker_params.clone();
         let blokli_config = self.config.blokli.clone();
+        let path_planner_min_ack_rate = self.config.connection.path_planner_min_ack_rate;
         let results_sender = results_sender.clone();
         tokio::spawn(async move {
             cancel
                 .run_until_cancelled(async move {
                     time::sleep(delay).await;
-                    runner::hopr(worker_params, blokli_config, &safe_module, results_sender).await;
+                    runner::hopr(worker_params, blokli_config, path_planner_min_ack_rate, &safe_module, results_sender).await;
                 })
                 .await
         });

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -1409,7 +1409,14 @@ impl Core {
             cancel
                 .run_until_cancelled(async move {
                     time::sleep(delay).await;
-                    runner::hopr(worker_params, blokli_config, path_planner_min_ack_rate, &safe_module, results_sender).await;
+                    runner::hopr(
+                        worker_params,
+                        blokli_config,
+                        path_planner_min_ack_rate,
+                        &safe_module,
+                        results_sender,
+                    )
+                    .await;
                 })
                 .await
         });

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -488,7 +488,7 @@ async fn run_hopr(
     results_sender: &mpsc::Sender<Results>,
 ) -> Result<Hopr, Error> {
     tracing::debug!("starting hopr runner");
-    let cfg = worker_params.to_config(safe_module).await?;
+    let cfg = worker_params.to_config(safe_module, path_planner_min_ack_rate).await?;
     let keys = worker_params.calc_keys().await?;
     let blokli_url = worker_params.blokli_url();
     let sender = results_sender.clone();
@@ -498,7 +498,7 @@ async fn run_hopr(
         }
     };
 
-    Hopr::new(cfg, keys, blokli_url, blokli_config.into(), path_planner_min_ack_rate, visitor)
+    Hopr::new(cfg, keys, blokli_url, blokli_config.into(), visitor)
         .await
         .map_err(Error::from)
 }

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -212,10 +212,11 @@ pub(crate) async fn persist_safe(state_home: PathBuf, safe_module: SafeModule, r
 pub(crate) async fn hopr(
     worker_params: WorkerParams,
     blokli_config: BlokliConfig,
+    path_planner_min_ack_rate: f64,
     safe_module: &SafeModule,
     results_sender: mpsc::Sender<Results>,
 ) {
-    let res = run_hopr(worker_params, blokli_config, safe_module, &results_sender).await;
+    let res = run_hopr(worker_params, blokli_config, path_planner_min_ack_rate, safe_module, &results_sender).await;
     let _ = results_sender
         .send(Results::Hopr {
             res,
@@ -482,6 +483,7 @@ async fn run_funding_tool(worker_params: WorkerParams, code: String) -> Result<O
 async fn run_hopr(
     worker_params: WorkerParams,
     blokli_config: BlokliConfig,
+    path_planner_min_ack_rate: f64,
     safe_module: &SafeModule,
     results_sender: &mpsc::Sender<Results>,
 ) -> Result<Hopr, Error> {
@@ -496,7 +498,7 @@ async fn run_hopr(
         }
     };
 
-    Hopr::new(cfg, keys, blokli_url, blokli_config.into(), visitor)
+    Hopr::new(cfg, keys, blokli_url, blokli_config.into(), path_planner_min_ack_rate, visitor)
         .await
         .map_err(Error::from)
 }

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -216,7 +216,14 @@ pub(crate) async fn hopr(
     safe_module: &SafeModule,
     results_sender: mpsc::Sender<Results>,
 ) {
-    let res = run_hopr(worker_params, blokli_config, path_planner_min_ack_rate, safe_module, &results_sender).await;
+    let res = run_hopr(
+        worker_params,
+        blokli_config,
+        path_planner_min_ack_rate,
+        safe_module,
+        &results_sender,
+    )
+    .await;
     let _ = results_sender
         .send(Results::Hopr {
             res,

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -325,8 +325,9 @@ impl Hopr {
             .await
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))?;
         for kind in &mut cfg.strategies {
-            let edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc) = kind;
-            lc.selector = edgli::strategy::SelectorProfile::LowLatency;
+            if let edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc) = kind {
+                lc.selector = edgli::strategy::SelectorProfile::LowLatency;
+            }
         }
         self.edgli
             .run_reactor_from_cfg(cfg)

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -48,15 +48,13 @@ pub struct Hopr {
 impl Hopr {
     #[instrument(skip_all, level = "debug", err)]
     pub async fn new(
-        mut cfg: edgli::hopr_lib::config::HoprLibConfig,
+        cfg: edgli::hopr_lib::config::HoprLibConfig,
         keys: edgli::hopr_lib::HoprKeys,
         blokli_url: Option<url::Url>,
         blokli_config: BlockchainConnectorConfig,
-        path_planner_min_ack_rate: f64,
         init_visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> Result<Self, HoprError> {
         tracing::debug!("running hopr edge node");
-        cfg.protocol.path_planner = edgli::latency_path_planner_config(path_planner_min_ack_rate);
         let edge_node = Edgli::new(
             cfg,
             keys,

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -48,17 +48,19 @@ pub struct Hopr {
 impl Hopr {
     #[instrument(skip_all, level = "debug", err)]
     pub async fn new(
-        cfg: edgli::hopr_lib::config::HoprLibConfig,
+        mut cfg: edgli::hopr_lib::config::HoprLibConfig,
         keys: edgli::hopr_lib::HoprKeys,
         blokli_url: Option<url::Url>,
         blokli_config: BlockchainConnectorConfig,
         init_visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> Result<Self, HoprError> {
         tracing::debug!("running hopr edge node");
+        cfg.protocol.path_planner = edgli::latency_path_planner_config(0.1);
         let edge_node = Edgli::new(
             cfg,
             keys,
             blokli_url.map(|u| u.to_string()),
+            None, // blokli_dns_override
             Some(blokli_config),
             init_visitor,
         )
@@ -319,9 +321,13 @@ impl Hopr {
         &self,
         sizing: edgli::strategy::IncentiveConfiguration,
     ) -> Result<AbortHandle, HoprError> {
-        let cfg = edgli::strategy::default_strategy_cfg(&self.edgli, &sizing)
+        let mut cfg = edgli::strategy::default_strategy_cfg(&self.edgli, &sizing)
             .await
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))?;
+        for kind in &mut cfg.strategies {
+            let edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc) = kind;
+            lc.selector = edgli::strategy::SelectorProfile::LowLatency;
+        }
         self.edgli
             .run_reactor_from_cfg(cfg)
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -40,6 +40,8 @@ use crate::{
     info::Info,
 };
 
+const PATH_PLANNER_MIN_ACK_RATE: f64 = 0.1;
+
 pub struct Hopr {
     edgli: Arc<edgli::Edgli>,
     open_listeners: Arc<ListenerJoinHandles>,
@@ -55,7 +57,7 @@ impl Hopr {
         init_visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> Result<Self, HoprError> {
         tracing::debug!("running hopr edge node");
-        cfg.protocol.path_planner = edgli::latency_path_planner_config(0.1);
+        cfg.protocol.path_planner = edgli::latency_path_planner_config(PATH_PLANNER_MIN_ACK_RATE);
         let edge_node = Edgli::new(
             cfg,
             keys,
@@ -324,10 +326,11 @@ impl Hopr {
         let mut cfg = edgli::strategy::default_strategy_cfg(&self.edgli, &sizing)
             .await
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))?;
-        for kind in &mut cfg.strategies {
-            if let edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc) = kind {
+        match cfg.strategies.first_mut() {
+            Some(edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc)) => {
                 lc.selector = edgli::strategy::SelectorProfile::LowLatency;
             }
+            None => tracing::warn!("default_strategy_cfg returned no strategies; LowLatency selector not applied"),
         }
         self.edgli
             .run_reactor_from_cfg(cfg)

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -40,8 +40,6 @@ use crate::{
     info::Info,
 };
 
-const PATH_PLANNER_MIN_ACK_RATE: f64 = 0.1;
-
 pub struct Hopr {
     edgli: Arc<edgli::Edgli>,
     open_listeners: Arc<ListenerJoinHandles>,
@@ -54,10 +52,11 @@ impl Hopr {
         keys: edgli::hopr_lib::HoprKeys,
         blokli_url: Option<url::Url>,
         blokli_config: BlockchainConnectorConfig,
+        path_planner_min_ack_rate: f64,
         init_visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> Result<Self, HoprError> {
         tracing::debug!("running hopr edge node");
-        cfg.protocol.path_planner = edgli::latency_path_planner_config(PATH_PLANNER_MIN_ACK_RATE);
+        cfg.protocol.path_planner = edgli::latency_path_planner_config(path_planner_min_ack_rate);
         let edge_node = Edgli::new(
             cfg,
             keys,

--- a/gnosis_vpn-lib/src/hopr/config.rs
+++ b/gnosis_vpn-lib/src/hopr/config.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 use tokio::fs;
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::compat::SafeModule;
 use crate::dirs;
@@ -64,30 +65,24 @@ pub async fn read_safe(state_home: PathBuf) -> Result<SafeModule, Error> {
     serde_saphyr::from_str::<SafeModule>(&content).map_err(Into::into)
 }
 
-pub async fn generate(safe_module: &SafeModule) -> Result<HoprLibConfig, Error> {
-    let content = format!(
-        r##"
-safe_module:
-    safe_address: {safe_address}
-    module_address: {module_address}
-publish: false
-protocol:
-    # Edge client: probe aggressively at startup so relay observations are
-    # populated before the first health check fires.  interval is the delay
-    # between probing rounds; it must be >= timeout (3 s).  recheck_threshold
-    # controls how quickly a relay gets re-examined after its last probe.
-    # At startup the graph needs to converge fast so health checks can
-    # succeed within the warm-up window — match interval so every relay
-    # is re-probed on every round.
-    probe:
-        timeout: 3s
-        interval: 3s
-        recheck_threshold: 3s
-"##,
-        safe_address = safe_module.safe_address,
-        module_address = safe_module.module_address,
-    );
-    serde_saphyr::from_str::<HoprLibConfig>(&content).map_err(Into::into)
+pub async fn generate(safe_module: &SafeModule, path_planner_min_ack_rate: f64) -> Result<HoprLibConfig, Error> {
+    let mut cfg = HoprLibConfig::default();
+    cfg.safe_module.safe_address = safe_module
+        .safe_address
+        .parse()
+        .map_err(|e| Error::Output(format!("invalid safe address: {e}")))?;
+    cfg.safe_module.module_address = safe_module
+        .module_address
+        .parse()
+        .map_err(|e| Error::Output(format!("invalid module address: {e}")))?;
+    // Edge client: probe aggressively at startup so relay observations are populated
+    // before the first health check fires. recheck_threshold matches interval so every
+    // relay is re-probed on every round during warm-up.
+    cfg.protocol.probe.timeout = Duration::from_secs(3);
+    cfg.protocol.probe.interval = Duration::from_secs(3);
+    cfg.protocol.probe.recheck_threshold = Duration::from_secs(3);
+    cfg.protocol.path_planner = edgli::latency_path_planner_config(path_planner_min_ack_rate);
+    Ok(cfg)
 }
 
 pub fn safe_file(state_home: PathBuf) -> PathBuf {

--- a/gnosis_vpn-lib/src/worker_params.rs
+++ b/gnosis_vpn-lib/src/worker_params.rs
@@ -131,12 +131,10 @@ impl WorkerParams {
         identity::from_path(identity_file, identity_pass.clone()).map_err(Error::from)
     }
 
-    pub async fn to_config(&self, safe_module: &SafeModule) -> Result<HoprLibConfig, Error> {
+    pub async fn to_config(&self, safe_module: &SafeModule, path_planner_min_ack_rate: f64) -> Result<HoprLibConfig, Error> {
         match self.config_mode.clone() {
-            // use user provided configuration path
             ConfigFileMode::Manual(path) => config::from_path(path).await.map_err(Error::from),
-            // check status of config generation
-            ConfigFileMode::Generated => config::generate(safe_module).await.map_err(Error::from),
+            ConfigFileMode::Generated => config::generate(safe_module, path_planner_min_ack_rate).await.map_err(Error::from),
         }
     }
 

--- a/gnosis_vpn-lib/src/worker_params.rs
+++ b/gnosis_vpn-lib/src/worker_params.rs
@@ -131,10 +131,16 @@ impl WorkerParams {
         identity::from_path(identity_file, identity_pass.clone()).map_err(Error::from)
     }
 
-    pub async fn to_config(&self, safe_module: &SafeModule, path_planner_min_ack_rate: f64) -> Result<HoprLibConfig, Error> {
+    pub async fn to_config(
+        &self,
+        safe_module: &SafeModule,
+        path_planner_min_ack_rate: f64,
+    ) -> Result<HoprLibConfig, Error> {
         match self.config_mode.clone() {
             ConfigFileMode::Manual(path) => config::from_path(path).await.map_err(Error::from),
-            ConfigFileMode::Generated => config::generate(safe_module, path_planner_min_ack_rate).await.map_err(Error::from),
+            ConfigFileMode::Generated => config::generate(safe_module, path_planner_min_ack_rate)
+                .await
+                .map_err(Error::from),
         }
     }
 


### PR DESCRIPTION
This PR wires gnosis_vpn-client unconditionally to the low-latency path-planning and channel-opening strategies introduced in hoprnet/edge-client#98: before constructing the HOPR node it sets a latency-optimised `PathPlannerConfig` so the path scorer strongly prefers low-RTT relays, and the channel lifecycle strategy selects `SelectorProfile::LowLatency` so channel-open candidates are ranked by latency rather than generic quality score. To access these APIs the `edgli` git dependency is bumped to the current main (`7da0fa5`), which conveniently aligns all transitive hopr crates onto the single `d670a6c` hoprnet rev that `hopr-utils-session` already pins.