### PR TITLE
feat(config): make bridge/wg target and ping address configurable per…

### DIFF
--- a/documented-config.toml
+++ b/documented-config.toml
@@ -21,6 +21,15 @@ version = 6
 # meta = { location = <location> }
 # session path: number of intermediate hops (0–3)
 # path = { hops = 1 }
+# override the bridge session's exit-side address for this destination only
+# (defaults to connection.bridge.target)
+# bridge_target = "172.30.0.1:8000"
+# override the wg session's exit-side address for this destination only
+# (defaults to connection.wg.target)
+# wg_target = "172.30.0.1:51820"
+# override the tunnel health-check ping address for this destination only
+# (defaults to the host part of this destination's wg_target)
+# ping_address = "172.30.0.1"
 
 [destinations.Germany]
 address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
@@ -71,9 +80,9 @@ path    = { hops = 1 }
 # capabilities = [ "segmentation", "no_delay" ]
 # target = "172.30.0.1:51820"
 
-# adjust internal session validation ping settings
+# adjust internal session validation ping settings (the ping address itself is
+# configured per destination — see destinations.<id>.ping_address above)
 # [connection.ping]
-# address = "10.128.0.1"
 # timeout = "15s"
 # ttl = 6
 # seq_count = 3

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -73,8 +73,11 @@ path    = { hops = 1 }
 # determine specific connection parameters for ephemeral bridge connection
 # (the session target itself is configured per destination — see
 # destinations.<id>.bridge_target above)
+# valid capabilities: "segmentation", "retransmission", "retransmission_ack_only",
+# "no_delay", "no_rate_control"
+# avoid retransmission capabilities on the bridge session — they require additional SURBs
 # [connection.bridge]
-# capabilities = [ "segmentation", "retransmission", "retransmission_ack_only", "no_rate_control" ]
+# capabilities = [ "segmentation", "no_rate_control" ]
 
 # determine specific connection parameters for persistent main connection
 # (the session target itself is configured per destination — see
@@ -132,7 +135,7 @@ path    = { hops = 1 }
 ## wireguard section - specific VPN-related settings
 
 # [wireguard]
-# interface listen port for incoming connections; defaults to 51820
+# interface listen port for incoming connections; when unset, WireGuard picks a random port
 # listen_port = 51820
 # manually overwrite derived allowed_ips for the WireGuard interface
 # allowed_ips = "0.0.0.0/0"
@@ -145,7 +148,7 @@ path    = { hops = 1 }
 ###
 ## chain provider section - query blockchain settings
 
-# see https://github.com/hoprnet/hoprnet/blob/6525d753fde70b5026d19d7a647b8143352b26df/chain/connector/src/connector/mod.rs#L46 for documentation
+# see https://github.com/hoprnet/hoprnet/blob/d601edc/impls/connector/src/connector/mod.rs#L79 for documentation
 # [blokli]
 # connection_sync_timeout = "30s"
 # sync_tolerance = 50

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -22,10 +22,10 @@ version = 6
 # session path: number of intermediate hops (0–3)
 # path = { hops = 1 }
 # override the bridge session's exit-side address for this destination only
-# (defaults to connection.bridge.target)
+# (defaults to 172.30.0.1:8000)
 # bridge_target = "172.30.0.1:8000"
 # override the wg session's exit-side address for this destination only
-# (defaults to connection.wg.target)
+# (defaults to 172.30.0.1:51820)
 # wg_target = "172.30.0.1:51820"
 # override the tunnel health-check ping address for this destination only
 # (defaults to the host part of this destination's wg_target)
@@ -71,14 +71,16 @@ path    = { hops = 1 }
 # path_planner_min_ack_rate = 0.1
 
 # determine specific connection parameters for ephemeral bridge connection
+# (the session target itself is configured per destination — see
+# destinations.<id>.bridge_target above)
 # [connection.bridge]
 # capabilities = [ "segmentation", "retransmission", "retransmission_ack_only", "no_rate_control" ]
-# target = "172.30.0.1:8000"
 
 # determine specific connection parameters for persistent main connection
+# (the session target itself is configured per destination — see
+# destinations.<id>.wg_target above)
 # [connection.wg]
 # capabilities = [ "segmentation", "no_delay" ]
-# target = "172.30.0.1:51820"
 
 # adjust internal session validation ping settings (the ping address itself is
 # configured per destination — see destinations.<id>.ping_address above)

--- a/gnosis_vpn-lib/src/command/balance_response.rs
+++ b/gnosis_vpn-lib/src/command/balance_response.rs
@@ -120,6 +120,7 @@ impl Display for ChannelBalance {
 mod tests {
     use super::*;
     use crate::connection::destination::{Destination, HopRouting};
+    use crate::connection::options;
 
     fn address(byte: u8) -> Address {
         Address::from([byte; 20])
@@ -131,6 +132,9 @@ mod tests {
             addr,
             HopRouting::try_from(1).expect("conversion cannot fail"),
             HashMap::new(),
+            options::default_bridge_target(),
+            options::default_wg_target(),
+            std::net::IpAddr::from([172, 30, 0, 1]),
         )
     }
 

--- a/gnosis_vpn-lib/src/command/mod.rs
+++ b/gnosis_vpn-lib/src/command/mod.rs
@@ -230,7 +230,7 @@ pub enum ConnectResponse {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum DisconnectResponse {
-    Disconnecting(Destination),
+    Disconnecting(Box<Destination>),
     NotConnected,
 }
 
@@ -387,7 +387,7 @@ impl ConnectResponse {
 
 impl DisconnectResponse {
     pub fn new(destination: Destination) -> Self {
-        DisconnectResponse::Disconnecting(destination)
+        DisconnectResponse::Disconnecting(Box::new(destination))
     }
 
     pub fn not_connected() -> Self {

--- a/gnosis_vpn-lib/src/command/mod.rs
+++ b/gnosis_vpn-lib/src/command/mod.rs
@@ -671,6 +671,7 @@ impl Display for RouteHealthView {
 mod tests {
     use super::*;
     use crate::connection::destination::HopRouting;
+    use crate::connection::options;
     use crate::gvpn_client;
     use crate::route_health::ExitHealth;
     use std::collections::HashMap;
@@ -685,6 +686,9 @@ mod tests {
             address(1),
             HopRouting::try_from(1).expect("conversion cannot fail"),
             HashMap::new(),
+            options::default_bridge_target(),
+            options::default_wg_target(),
+            std::net::IpAddr::from([172, 30, 0, 1]),
         )
     }
 

--- a/gnosis_vpn-lib/src/config/mod.rs
+++ b/gnosis_vpn-lib/src/config/mod.rs
@@ -99,3 +99,17 @@ pub async fn read(path: &Path) -> Result<Config, Error> {
         _ => Err(Error::VersionMismatch(version as u8)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Keeps the shipped example config in sync with the schema: it must parse as the
+    // current version without any ignored keys.
+    #[test]
+    fn documented_config_matches_current_schema() {
+        let content = include_str!("../../../documented-config.toml");
+        let table = content.parse::<toml::Table>().expect("valid TOML");
+        assert_eq!(super::v6::wrong_keys(&table), Vec::<String>::new());
+        let cfg = toml::from_str::<super::v6::Config>(content).expect("deserializes as v6");
+        let _: super::Config = cfg.try_into().expect("converts to runtime config");
+    }
+}

--- a/gnosis_vpn-lib/src/config/v3.rs
+++ b/gnosis_vpn-lib/src/config/v3.rs
@@ -163,8 +163,12 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
-        let connection = value.connection.into();
-        let destinations = v4::convert_destinations(value.destinations)?;
+        let connection: crate::connection::options::Options = value.connection.into();
+        let destinations = v4::convert_destinations(
+            value.destinations,
+            &connection.sessions.bridge.target,
+            &connection.sessions.wg.target,
+        )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {

--- a/gnosis_vpn-lib/src/config/v3.rs
+++ b/gnosis_vpn-lib/src/config/v3.rs
@@ -163,11 +163,17 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
+        let legacy_ping_address = value
+            .connection
+            .as_ref()
+            .and_then(|c| c.ping.as_ref())
+            .and_then(|p| p.address);
         let connection: crate::connection::options::Options = value.connection.into();
         let destinations = v4::convert_destinations(
             value.destinations,
             &connection.sessions.bridge.target,
             &connection.sessions.wg.target,
+            legacy_ping_address,
         )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
@@ -210,6 +216,26 @@ address = "10.128.0.1"
 
 "#####;
         toml::from_str::<Config>(config)?;
+        Ok(())
+    }
+
+    #[test]
+    fn connection_ping_address_is_parsed_and_forwarded_end_to_end() -> anyhow::Result<()> {
+        let config = r#####"
+version = 3
+[hoprd_node]
+endpoint = "http://127.0.0.1:3001"
+api_token = "1234567890"
+
+[destinations.0xD9c11f07BfBC1914877d7395459223aFF9Dc2739]
+
+[connection.ping]
+address = "10.128.0.1"
+"#####;
+        let cfg = toml::from_str::<Config>(config)?;
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        let d = result.destinations.values().next().unwrap();
+        assert_eq!(d.ping_address, "10.128.0.1".parse::<std::net::IpAddr>().unwrap());
         Ok(())
     }
 

--- a/gnosis_vpn-lib/src/config/v3.rs
+++ b/gnosis_vpn-lib/src/config/v3.rs
@@ -168,13 +168,13 @@ impl TryFrom<Config> for config::Config {
             .as_ref()
             .and_then(|c| c.ping.as_ref())
             .and_then(|p| p.address);
-        let connection: crate::connection::options::Options = value.connection.into();
         let destinations = v4::convert_destinations(
             value.destinations,
-            &connection.sessions.bridge.target,
-            &connection.sessions.wg.target,
+            &v5::legacy_bridge_target(value.connection.as_ref()),
+            &v5::legacy_wg_target(value.connection.as_ref()),
             legacy_ping_address,
         )?;
+        let connection: crate::connection::options::Options = value.connection.into();
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -1,5 +1,6 @@
 use edgli::hopr_lib::HopRouting;
 use edgli::hopr_lib::api::types::primitive::prelude::Address;
+use edgli::hopr_lib::exports::transport::SessionTarget;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
@@ -9,7 +10,9 @@ use std::vec::Vec;
 
 use crate::config;
 use crate::config::v5;
+use crate::config::v6;
 use crate::connection::destination::Destination as ConnDestination;
+use crate::connection::options;
 
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -131,8 +134,12 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
-        let connection = value.connection.into();
-        let destinations = convert_destinations(value.destinations)?;
+        let connection: options::Options = value.connection.into();
+        let destinations = convert_destinations(
+            value.destinations,
+            &connection.sessions.bridge.target,
+            &connection.sessions.wg.target,
+        )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {
@@ -147,11 +154,17 @@ impl TryFrom<Config> for config::Config {
 
 pub fn convert_destinations(
     value: Option<HashMap<Address, Destination>>,
+    default_bridge_target: &SessionTarget,
+    default_wg_target: &SessionTarget,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
         return Err(config::Error::NoDestinations);
     }
+
+    // v4 doesn't support per-destination target/ping overrides — every destination
+    // gets the global default, with the ping address derived from the wg target's IP.
+    let ping_address = v6::ip_of(default_wg_target);
 
     let mut result = HashMap::new();
     for (address, dest) in config_dests.iter() {
@@ -167,7 +180,15 @@ pub fn convert_destinations(
 
         let meta = dest.meta.clone().unwrap_or_default();
 
-        let dest = ConnDestination::new(address.to_string(), *address, path, meta);
+        let dest = ConnDestination::new(
+            address.to_string(),
+            *address,
+            path,
+            meta,
+            default_bridge_target.clone(),
+            default_wg_target.clone(),
+            ping_address,
+        );
         result.insert(address.to_string(), dest);
     }
     Ok(result)
@@ -176,6 +197,7 @@ pub fn convert_destinations(
 #[cfg(test)]
 mod tests {
     use super::{Config, convert_destinations};
+    use crate::connection::options;
     use edgli::hopr_lib::HopRouting;
 
     fn parse(toml: &str) -> Config {
@@ -192,7 +214,12 @@ version = 4
 path = { hops = 2 }
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(2).unwrap());
     }
@@ -207,7 +234,12 @@ version = 4
 path = { intermediates = ["0xD88064F7023D5dA2Efa35eAD1602d5F5d86BB6BA", "0x25865191AdDe377fd85E91566241178070F4797A"] }
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(2).unwrap());
     }
@@ -222,7 +254,12 @@ version = 4
 path = { intermediates = ["0xD88064F7023D5dA2Efa35eAD1602d5F5d86BB6BA", "0x25865191AdDe377fd85E91566241178070F4797A", "0x8a6E6200C9dE8d8F8D9b4c08F86500a2E3Fbf254", "0xa5Ca174Ef94403d6162a969341a61baeA48F57F8"] }
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(3).unwrap());
     }
@@ -236,20 +273,29 @@ version = 4
 [destinations.0xD9c11f07BfBC1914877d7395459223aFF9Dc2739]
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(1).unwrap());
     }
 
     #[test]
     fn convert_destinations_empty_map_errors() {
-        let result = convert_destinations(Some(std::collections::HashMap::new()));
+        let result = convert_destinations(
+            Some(std::collections::HashMap::new()),
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None);
+        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
         assert!(result.is_err());
     }
 

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -139,13 +139,13 @@ impl TryFrom<Config> for config::Config {
             .as_ref()
             .and_then(|c| c.ping.as_ref())
             .and_then(|p| p.address);
-        let connection: options::Options = value.connection.into();
         let destinations = convert_destinations(
             value.destinations,
-            &connection.sessions.bridge.target,
-            &connection.sessions.wg.target,
+            &v5::legacy_bridge_target(value.connection.as_ref()),
+            &v5::legacy_wg_target(value.connection.as_ref()),
             legacy_ping_address,
         )?;
+        let connection: options::Options = value.connection.into();
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -169,9 +169,8 @@ pub fn convert_destinations(
         return Err(config::Error::NoDestinations);
     }
 
-    // v4 doesn't support per-destination target/ping overrides — every destination gets the
-    // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
-    // from the config file, if present; otherwise it falls back to the default wg IP.
+    // v4 has no per-destination overrides: every destination gets the global targets,
+    // and the deprecated `connection.ping.address` (when set) as its ping address.
     let ping_address = legacy_ping_address.unwrap_or_else(options::default_wg_ip);
 
     let mut result = HashMap::new();

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -11,7 +11,6 @@ use std::vec::Vec;
 
 use crate::config;
 use crate::config::v5;
-use crate::config::v6;
 use crate::connection::destination::Destination as ConnDestination;
 use crate::connection::options;
 
@@ -172,8 +171,8 @@ pub fn convert_destinations(
 
     // v4 doesn't support per-destination target/ping overrides — every destination gets the
     // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
-    // from the config file, if present; otherwise it's derived from the wg target's IP.
-    let ping_address = legacy_ping_address.unwrap_or_else(|| v6::ip_of(default_wg_target));
+    // from the config file, if present; otherwise it falls back to the default wg IP.
+    let ping_address = legacy_ping_address.unwrap_or_else(options::default_wg_ip);
 
     let mut result = HashMap::new();
     for (address, dest) in config_dests.iter() {

--- a/gnosis_vpn-lib/src/config/v4.rs
+++ b/gnosis_vpn-lib/src/config/v4.rs
@@ -6,6 +6,7 @@ use serde_with::{DisplayFromStr, serde_as};
 
 use std::cmp::PartialEq;
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::vec::Vec;
 
 use crate::config;
@@ -134,11 +135,17 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
+        let legacy_ping_address = value
+            .connection
+            .as_ref()
+            .and_then(|c| c.ping.as_ref())
+            .and_then(|p| p.address);
         let connection: options::Options = value.connection.into();
         let destinations = convert_destinations(
             value.destinations,
             &connection.sessions.bridge.target,
             &connection.sessions.wg.target,
+            legacy_ping_address,
         )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
@@ -156,15 +163,17 @@ pub fn convert_destinations(
     value: Option<HashMap<Address, Destination>>,
     default_bridge_target: &SessionTarget,
     default_wg_target: &SessionTarget,
+    legacy_ping_address: Option<IpAddr>,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
         return Err(config::Error::NoDestinations);
     }
 
-    // v4 doesn't support per-destination target/ping overrides — every destination
-    // gets the global default, with the ping address derived from the wg target's IP.
-    let ping_address = v6::ip_of(default_wg_target);
+    // v4 doesn't support per-destination target/ping overrides — every destination gets the
+    // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
+    // from the config file, if present; otherwise it's derived from the wg target's IP.
+    let ping_address = legacy_ping_address.unwrap_or_else(|| v6::ip_of(default_wg_target));
 
     let mut result = HashMap::new();
     for (address, dest) in config_dests.iter() {
@@ -218,6 +227,7 @@ path = { hops = 2 }
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -238,6 +248,7 @@ path = { intermediates = ["0xD88064F7023D5dA2Efa35eAD1602d5F5d86BB6BA", "0x25865
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -258,6 +269,7 @@ path = { intermediates = ["0xD88064F7023D5dA2Efa35eAD1602d5F5d86BB6BA", "0x25865
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -277,6 +289,7 @@ version = 4
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -289,14 +302,58 @@ version = 4
             Some(std::collections::HashMap::new()),
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         );
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
+        let result = convert_destinations(
+            None,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+            None,
+        );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn convert_destinations_forwards_legacy_connection_ping_address() {
+        let cfg = parse(
+            r#####"
+version = 4
+
+[destinations.0xD9c11f07BfBC1914877d7395459223aFF9Dc2739]
+"#####,
+        );
+        let legacy_ping_address = "10.128.0.1".parse().unwrap();
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+            Some(legacy_ping_address),
+        )
+        .expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(d.ping_address, legacy_ping_address);
+    }
+
+    #[test]
+    fn connection_ping_address_is_parsed_and_forwarded_end_to_end() {
+        let cfg = parse(
+            r#####"
+version = 4
+
+[destinations.0xD9c11f07BfBC1914877d7395459223aFF9Dc2739]
+
+[connection.ping]
+address = "10.128.0.1"
+"#####,
+        );
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        let d = result.destinations.values().next().unwrap();
+        assert_eq!(d.ping_address, "10.128.0.1".parse::<std::net::IpAddr>().unwrap());
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -16,10 +16,9 @@ use crate::config;
 use crate::connection::{destination::Destination as ConnDestination, options};
 use crate::ping;
 
-// Types from v6 that are schema-identical in v5 are re-used directly.
-// Connection, PingOptions, BufferOptions, and MaxSurbUpstreamOptions are defined below:
-// v5 uses separate `buffer` and `max_surb_upstream` sections instead of `surb_balancing`,
-// and v5's `ping` still accepts the deprecated `address` field that v6 dropped.
+// Types from v6 that are schema-identical in v5 are re-used directly. Types that
+// diverge (Connection, PingOptions, BufferOptions, MaxSurbUpstreamOptions) are
+// defined below, each with the reason it differs.
 pub(super) use super::v6::{
     BlokliConfig, Capability, ConnectionProtocol, HealthCheckIntervalOptions, WireGuard, to_flags,
 };
@@ -40,10 +39,8 @@ pub(super) struct Connection {
     pub(super) health_check_intervals: Option<HealthCheckIntervalOptions>,
 }
 
-// v5 defines its own PingOptions (rather than reusing v6's) because it still accepts the
-// deprecated `address` field: older configs set the global ping target here, and that value
-// is forward-converted into each destination's `ping_address` since v5 has no per-destination
-// override of its own. v6 dropped the field entirely in favor of `destination.ping_address`.
+// Unlike v6, v5 still accepts the deprecated `address` field; its value is
+// forward-converted into every destination's `ping_address`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(super) struct PingOptions {
     pub(super) address: Option<IpAddr>,
@@ -397,9 +394,8 @@ pub fn convert_destinations(
         return Err(config::Error::NoDestinations);
     }
 
-    // v5 doesn't support per-destination target/ping overrides — every destination gets the
-    // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
-    // from the config file, if present; otherwise it falls back to the default wg IP.
+    // v5 has no per-destination overrides: every destination gets the global targets,
+    // and the deprecated `connection.ping.address` (when set) as its ping address.
     let ping_address = legacy_ping_address.unwrap_or_else(options::default_wg_ip);
 
     let mut result = HashMap::new();

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::time::Duration;
 use std::vec::Vec;
 
@@ -65,20 +64,6 @@ impl Connection {
         vec![Capability::Segmentation, Capability::NoDelay]
     }
 
-    pub fn default_bridge_target() -> SessionTarget {
-        SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
-            [172, 30, 0, 1],
-            8000,
-        )))))
-    }
-
-    pub fn default_wg_target() -> SessionTarget {
-        SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
-            [172, 30, 0, 1],
-            51820,
-        )))))
-    }
-
     pub fn default_http_timeout() -> Duration {
         Duration::from_secs(60)
     }
@@ -123,7 +108,7 @@ impl From<Option<Connection>> for options::Options {
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.target)
             .map(|socket| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(Connection::default_bridge_target());
+            .unwrap_or(options::default_bridge_target());
         let bridge_caps = connection
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.capabilities.clone())
@@ -134,7 +119,7 @@ impl From<Option<Connection>> for options::Options {
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.target)
             .map(|socket| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(Connection::default_wg_target());
+            .unwrap_or(options::default_wg_target());
         let wg_caps = connection
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.capabilities.clone())
@@ -147,10 +132,12 @@ impl From<Option<Connection>> for options::Options {
         };
 
         let def_opts = ping::Options::default();
+        // `address` is a placeholder here — every real ping is issued with
+        // `destination.ping_address` substituted in at the call site.
         let ping_opts = connection
             .and_then(|c| c.ping.as_ref())
             .map(|p| ping::Options {
-                address: p.address.unwrap_or(def_opts.address),
+                address: def_opts.address,
                 timeout: p.timeout.unwrap_or(def_opts.timeout),
                 ttl: p.ttl.unwrap_or(def_opts.ttl),
                 seq_count: p.seq_count.unwrap_or(def_opts.seq_count),
@@ -360,8 +347,12 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
-        let connection = value.connection.into();
-        let destinations = convert_destinations(value.destinations)?;
+        let connection: options::Options = value.connection.into();
+        let destinations = convert_destinations(
+            value.destinations,
+            &connection.sessions.bridge.target,
+            &connection.sessions.wg.target,
+        )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {
@@ -376,11 +367,17 @@ impl TryFrom<Config> for config::Config {
 
 pub fn convert_destinations(
     value: Option<HashMap<String, Destination>>,
+    default_bridge_target: &SessionTarget,
+    default_wg_target: &SessionTarget,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
         return Err(config::Error::NoDestinations);
     }
+
+    // v5 doesn't support per-destination target/ping overrides — every destination
+    // gets the global default, with the ping address derived from the wg target's IP.
+    let ping_address = super::v6::ip_of(default_wg_target);
 
     let mut result = HashMap::new();
     for (id, dest) in config_dests.iter() {
@@ -400,7 +397,15 @@ pub fn convert_destinations(
 
         let meta = dest.meta.clone().unwrap_or_default();
 
-        let dest = ConnDestination::new(id.to_string(), dest.address, path, meta);
+        let dest = ConnDestination::new(
+            id.to_string(),
+            dest.address,
+            path,
+            meta,
+            default_bridge_target.clone(),
+            default_wg_target.clone(),
+            ping_address,
+        );
         result.insert(id.to_string(), dest);
     }
     Ok(result)
@@ -409,6 +414,7 @@ pub fn convert_destinations(
 #[cfg(test)]
 mod tests {
     use super::{Config, convert_destinations};
+    use crate::connection::options;
     use edgli::hopr_lib::HopRouting;
 
     fn parse(toml: &str) -> Config {
@@ -426,7 +432,12 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
 path = { hops = 2 }
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(2).unwrap());
     }
@@ -441,20 +452,29 @@ version = 5
 address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
+        .expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(1).unwrap());
     }
 
     #[test]
     fn convert_destinations_empty_map_errors() {
-        let result = convert_destinations(Some(std::collections::HashMap::new()));
+        let result = convert_destinations(
+            Some(std::collections::HashMap::new()),
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None);
+        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
         assert!(result.is_err());
     }
 

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::time::Duration;
 use std::vec::Vec;
 
@@ -16,10 +17,11 @@ use crate::connection::{destination::Destination as ConnDestination, options};
 use crate::ping;
 
 // Types from v6 that are schema-identical in v5 are re-used directly.
-// Connection, BufferOptions, and MaxSurbUpstreamOptions are defined below because
-// v5 uses separate `buffer` and `max_surb_upstream` sections instead of `surb_balancing`.
+// Connection, PingOptions, BufferOptions, and MaxSurbUpstreamOptions are defined below:
+// v5 uses separate `buffer` and `max_surb_upstream` sections instead of `surb_balancing`,
+// and v5's `ping` still accepts the deprecated `address` field that v6 dropped.
 pub(super) use super::v6::{
-    BlokliConfig, Capability, ConnectionProtocol, HealthCheckIntervalOptions, PingOptions, WireGuard, to_flags,
+    BlokliConfig, Capability, ConnectionProtocol, HealthCheckIntervalOptions, WireGuard, to_flags,
 };
 use super::v6::{MAX_HOPS, validate_hops};
 
@@ -36,6 +38,19 @@ pub(super) struct Connection {
     pub(super) max_surb_upstream: Option<MaxSurbUpstreamOptions>,
     pub(super) announced_peer_minimum_score: Option<f64>,
     pub(super) health_check_intervals: Option<HealthCheckIntervalOptions>,
+}
+
+// v5 defines its own PingOptions (rather than reusing v6's) because it still accepts the
+// deprecated `address` field: older configs set the global ping target here, and that value
+// is forward-converted into each destination's `ping_address` since v5 has no per-destination
+// override of its own. v6 dropped the field entirely in favor of `destination.ping_address`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(super) struct PingOptions {
+    pub(super) address: Option<IpAddr>,
+    #[serde(default, with = "humantime_serde::option")]
+    pub(super) timeout: Option<Duration>,
+    pub(super) ttl: Option<u32>,
+    pub(super) seq_count: Option<u16>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -347,11 +362,17 @@ impl TryFrom<Config> for config::Config {
     type Error = config::Error;
 
     fn try_from(value: Config) -> Result<Self, Self::Error> {
+        let legacy_ping_address = value
+            .connection
+            .as_ref()
+            .and_then(|c| c.ping.as_ref())
+            .and_then(|p| p.address);
         let connection: options::Options = value.connection.into();
         let destinations = convert_destinations(
             value.destinations,
             &connection.sessions.bridge.target,
             &connection.sessions.wg.target,
+            legacy_ping_address,
         )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
@@ -369,15 +390,17 @@ pub fn convert_destinations(
     value: Option<HashMap<String, Destination>>,
     default_bridge_target: &SessionTarget,
     default_wg_target: &SessionTarget,
+    legacy_ping_address: Option<IpAddr>,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
         return Err(config::Error::NoDestinations);
     }
 
-    // v5 doesn't support per-destination target/ping overrides — every destination
-    // gets the global default, with the ping address derived from the wg target's IP.
-    let ping_address = super::v6::ip_of(default_wg_target);
+    // v5 doesn't support per-destination target/ping overrides — every destination gets the
+    // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
+    // from the config file, if present; otherwise it's derived from the wg target's IP.
+    let ping_address = legacy_ping_address.unwrap_or_else(|| super::v6::ip_of(default_wg_target));
 
     let mut result = HashMap::new();
     for (id, dest) in config_dests.iter() {
@@ -436,6 +459,7 @@ path = { hops = 2 }
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -456,6 +480,7 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
             cfg.destinations,
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
@@ -468,14 +493,81 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
             Some(std::collections::HashMap::new()),
             &options::default_bridge_target(),
             &options::default_wg_target(),
+            None,
         );
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
+        let result = convert_destinations(
+            None,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+            None,
+        );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn convert_destinations_ping_address_defaults_to_wg_target_ip() {
+        let cfg = parse(
+            r#####"
+version = 5
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+"#####,
+        );
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+            None,
+        )
+        .expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(d.ping_address, super::super::v6::ip_of(&options::default_wg_target()));
+    }
+
+    #[test]
+    fn convert_destinations_forwards_legacy_connection_ping_address() {
+        let cfg = parse(
+            r#####"
+version = 5
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+"#####,
+        );
+        let legacy_ping_address = "10.128.0.1".parse().unwrap();
+        let result = convert_destinations(
+            cfg.destinations,
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+            Some(legacy_ping_address),
+        )
+        .expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(d.ping_address, legacy_ping_address);
+    }
+
+    #[test]
+    fn connection_ping_address_is_parsed_and_forwarded_end_to_end() {
+        let cfg = parse(
+            r#####"
+version = 5
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+
+[connection.ping]
+address = "10.128.0.1"
+"#####,
+        );
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        let d = result.destinations.values().next().unwrap();
+        assert_eq!(d.ping_address, "10.128.0.1".parse::<std::net::IpAddr>().unwrap());
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -399,8 +399,8 @@ pub fn convert_destinations(
 
     // v5 doesn't support per-destination target/ping overrides — every destination gets the
     // global default. `legacy_ping_address` forwards a deprecated `connection.ping.address`
-    // from the config file, if present; otherwise it's derived from the wg target's IP.
-    let ping_address = legacy_ping_address.unwrap_or_else(|| super::v6::ip_of(default_wg_target));
+    // from the config file, if present; otherwise it falls back to the default wg IP.
+    let ping_address = legacy_ping_address.unwrap_or_else(options::default_wg_ip);
 
     let mut result = HashMap::new();
     for (id, dest) in config_dests.iter() {
@@ -527,7 +527,7 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
         )
         .expect("should succeed");
         let d = result.values().next().unwrap();
-        assert_eq!(d.ping_address, super::super::v6::ip_of(&options::default_wg_target()));
+        assert_eq!(d.ping_address, options::default_wg_ip());
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v5.rs
+++ b/gnosis_vpn-lib/src/config/v5.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 use std::vec::Vec;
 
@@ -19,9 +19,7 @@ use crate::ping;
 // Types from v6 that are schema-identical in v5 are re-used directly. Types that
 // diverge (Connection, PingOptions, BufferOptions, MaxSurbUpstreamOptions) are
 // defined below, each with the reason it differs.
-pub(super) use super::v6::{
-    BlokliConfig, Capability, ConnectionProtocol, HealthCheckIntervalOptions, WireGuard, to_flags,
-};
+pub(super) use super::v6::{BlokliConfig, Capability, HealthCheckIntervalOptions, WireGuard, to_flags};
 use super::v6::{MAX_HOPS, validate_hops};
 
 // v5 defines its own Connection to carry the separate `buffer` and `max_surb_upstream`
@@ -37,6 +35,14 @@ pub(super) struct Connection {
     pub(super) max_surb_upstream: Option<MaxSurbUpstreamOptions>,
     pub(super) announced_peer_minimum_score: Option<f64>,
     pub(super) health_check_intervals: Option<HealthCheckIntervalOptions>,
+}
+
+// Unlike v6, v5 still accepts the deprecated global `target` field; its value is
+// forward-converted into every destination's `bridge_target`/`wg_target`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(super) struct ConnectionProtocol {
+    pub(super) capabilities: Option<Vec<Capability>>,
+    pub(super) target: Option<SocketAddr>,
 }
 
 // Unlike v6, v5 still accepts the deprecated `address` field; its value is
@@ -113,34 +119,37 @@ fn build_surb_balancing(buf: Option<BufferOptions>, surbs: Option<MaxSurbUpstrea
     }
 }
 
+// Effective global session targets of legacy configs (v3–v5): the deprecated
+// `connection.{bridge,wg}.target`, falling back to the built-in defaults. Used to
+// forward-convert into every destination's `bridge_target`/`wg_target`.
+pub(super) fn legacy_bridge_target(conn: Option<&Connection>) -> SessionTarget {
+    conn.and_then(|c| c.bridge.as_ref())
+        .and_then(|b| b.target)
+        .map(|socket| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
+        .unwrap_or_else(options::default_bridge_target)
+}
+
+pub(super) fn legacy_wg_target(conn: Option<&Connection>) -> SessionTarget {
+    conn.and_then(|c| c.wg.as_ref())
+        .and_then(|w| w.target)
+        .map(|socket| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
+        .unwrap_or_else(options::default_wg_target)
+}
+
 impl From<Option<Connection>> for options::Options {
     fn from(conn: Option<Connection>) -> Self {
         let connection = conn.as_ref();
-        let bridge_target = connection
-            .and_then(|c| c.bridge.as_ref())
-            .and_then(|b| b.target)
-            .map(|socket| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(options::default_bridge_target());
         let bridge_caps = connection
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.capabilities.clone())
             .unwrap_or(Connection::default_bridge_capabilities());
-        let params_bridge = options::SessionParameters::new(bridge_target, to_flags(bridge_caps));
-
-        let wg_target = connection
-            .and_then(|c| c.wg.as_ref())
-            .and_then(|w| w.target)
-            .map(|socket| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(options::default_wg_target());
         let wg_caps = connection
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.capabilities.clone())
             .unwrap_or(Connection::default_wg_capabilities());
-        let params_wg = options::SessionParameters::new(wg_target, to_flags(wg_caps));
-
         let sessions = options::Sessions {
-            bridge: params_bridge,
-            wg: params_wg,
+            bridge_capabilities: to_flags(bridge_caps),
+            wg_capabilities: to_flags(wg_caps),
         };
 
         let def_opts = ping::Options::default();
@@ -364,13 +373,13 @@ impl TryFrom<Config> for config::Config {
             .as_ref()
             .and_then(|c| c.ping.as_ref())
             .and_then(|p| p.address);
-        let connection: options::Options = value.connection.into();
         let destinations = convert_destinations(
             value.destinations,
-            &connection.sessions.bridge.target,
-            &connection.sessions.wg.target,
+            &legacy_bridge_target(value.connection.as_ref()),
+            &legacy_wg_target(value.connection.as_ref()),
             legacy_ping_address,
         )?;
+        let connection: options::Options = value.connection.into();
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         Ok(config::Config {
@@ -564,6 +573,36 @@ address = "10.128.0.1"
         let result: crate::config::Config = cfg.try_into().expect("should succeed");
         let d = result.destinations.values().next().unwrap();
         assert_eq!(d.ping_address, "10.128.0.1".parse::<std::net::IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn connection_targets_are_parsed_and_forwarded_end_to_end() {
+        use edgli::hopr_lib::exports::network::types::types::{IpOrHost, SealedHost};
+        use edgli::hopr_lib::exports::transport::SessionTarget;
+        let cfg = parse(
+            r#####"
+version = 5
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+
+[connection.bridge]
+target = "10.0.0.5:8000"
+
+[connection.wg]
+target = "10.0.0.5:51820"
+"#####,
+        );
+        let result: crate::config::Config = cfg.try_into().expect("should succeed");
+        let d = result.destinations.values().next().unwrap();
+        assert_eq!(
+            d.bridge_target,
+            SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip("10.0.0.5:8000".parse().unwrap())))
+        );
+        assert_eq!(
+            d.wg_target,
+            SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip("10.0.0.5:51820".parse().unwrap())))
+        );
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -907,7 +907,7 @@ path_planner_min_ack_rate = {bad}
             target_open_channels: None,
             channel_allowlist: Some(ChannelAllowlistConfig {
                 enabled: true,
-                peers: vec![addr.clone()],
+                peers: vec![addr],
             }),
         });
         let cfg: StrategyConfig = strategy.into();

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -635,18 +635,6 @@ impl TryFrom<Config> for config::Config {
     }
 }
 
-/// Extracts the plain IP from a `SessionTarget` built by this module — always
-/// `TcpStream`/`UdpStream(SealedHost::Plain(IpOrHost::Ip(_)))`, since that's the only
-/// shape `bridge_target`/`wg_target` are ever constructed in (see `default_bridge_target`,
-/// `default_wg_target`, and the `SocketAddr`-only TOML `target`/`bridge_target`/`wg_target` fields).
-pub(super) fn ip_of(target: &SessionTarget) -> IpAddr {
-    match target {
-        SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(addr)))
-        | SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(addr))) => addr.ip(),
-        other => unreachable!("bridge/wg targets are always plain IP sockets, got {other:?}"),
-    }
-}
-
 pub fn convert_destinations(
     value: Option<HashMap<String, Destination>>,
     default_bridge_target: &SessionTarget,
@@ -673,7 +661,10 @@ pub fn convert_destinations(
             .wg_target
             .map(|addr| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(addr))))
             .unwrap_or_else(|| default_wg_target.clone());
-        let ping_address = dest.ping_address.unwrap_or_else(|| ip_of(&wg_target));
+        let ping_address = dest
+            .ping_address
+            .or_else(|| dest.wg_target.map(|addr| addr.ip()))
+            .unwrap_or_else(options::default_wg_ip);
         let dest = ConnDestination::new(
             id.to_string(),
             dest.address,

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -68,7 +68,6 @@ pub(super) struct ConnectionProtocol {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(super) struct PingOptions {
-    pub(super) address: Option<IpAddr>,
     #[serde(default, with = "humantime_serde::option")]
     pub(super) timeout: Option<Duration>,
     pub(super) ttl: Option<u32>,
@@ -215,20 +214,6 @@ impl Connection {
         vec![Capability::Segmentation, Capability::NoDelay]
     }
 
-    pub fn default_bridge_target() -> SessionTarget {
-        SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
-            [172, 30, 0, 1],
-            8000,
-        )))))
-    }
-
-    pub fn default_wg_target() -> SessionTarget {
-        SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
-            [172, 30, 0, 1],
-            51820,
-        )))))
-    }
-
     pub fn default_http_timeout() -> Duration {
         Duration::from_secs(60)
     }
@@ -256,7 +241,7 @@ impl From<Option<Connection>> for options::Options {
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.target)
             .map(|socket| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(Connection::default_bridge_target());
+            .unwrap_or(options::default_bridge_target());
         let bridge_caps = connection
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.capabilities.clone())
@@ -267,7 +252,7 @@ impl From<Option<Connection>> for options::Options {
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.target)
             .map(|socket| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(Connection::default_wg_target());
+            .unwrap_or(options::default_wg_target());
         let wg_caps = connection
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.capabilities.clone())
@@ -280,10 +265,12 @@ impl From<Option<Connection>> for options::Options {
         };
 
         let def_opts = ping::Options::default();
+        // `address` is a placeholder here — every real ping is issued with
+        // `destination.ping_address` substituted in at the call site.
         let ping_opts = connection
             .and_then(|c| c.ping.as_ref())
             .map(|p| ping::Options {
-                address: p.address.unwrap_or(def_opts.address),
+                address: def_opts.address,
                 timeout: p.timeout.unwrap_or(def_opts.timeout),
                 ttl: p.ttl.unwrap_or(def_opts.ttl),
                 seq_count: p.seq_count.unwrap_or(def_opts.seq_count),
@@ -442,7 +429,7 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
                     if k == "ping" {
                         if let Some(ping) = v.as_table() {
                             for (k2, _) in ping.iter() {
-                                if k2 == "address" || k2 == "timeout" || k2 == "ttl" || k2 == "seq_count" {
+                                if k2 == "timeout" || k2 == "ttl" || k2 == "seq_count" {
                                     continue;
                                 }
                                 wrong.push(format!("connection.ping.{k2}"));
@@ -499,7 +486,13 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
                 for (id, v) in destinations.iter() {
                     if let Some(dest) = v.as_table() {
                         for (k, _) in dest.iter() {
-                            if k == "address" || k == "meta" || k == "path" {
+                            if k == "address"
+                                || k == "meta"
+                                || k == "path"
+                                || k == "bridge_target"
+                                || k == "wg_target"
+                                || k == "ping_address"
+                            {
                                 continue;
                             }
                             wrong.push(format!("destinations.{id}.{k}"));
@@ -596,6 +589,13 @@ pub(super) struct Destination {
     pub(super) address: Address,
     pub(super) meta: Option<HashMap<String, String>>,
     pub(super) path: Option<DestinationPath>,
+    /// Overrides the exit-side address the bridge session connects to for this destination only.
+    pub(super) bridge_target: Option<SocketAddr>,
+    /// Overrides the exit-side address the wg session connects to for this destination only.
+    pub(super) wg_target: Option<SocketAddr>,
+    /// Overrides the tunnel health-check ping address for this destination only.
+    /// Defaults to the host part of this destination's `wg_target` when absent.
+    pub(super) ping_address: Option<IpAddr>,
 }
 
 /// Routing path for v6 — only hop-count routing is supported.
@@ -617,7 +617,11 @@ impl TryFrom<Config> for config::Config {
         if connection.surb_balancing.ping.enabled != connection.surb_balancing.main.enabled {
             return Err(config::Error::SurbBalancingMismatch);
         }
-        let destinations = convert_destinations(value.destinations)?;
+        let destinations = convert_destinations(
+            value.destinations,
+            &connection.sessions.bridge.target,
+            &connection.sessions.wg.target,
+        )?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         let strategy = value.strategy.into();
@@ -631,8 +635,22 @@ impl TryFrom<Config> for config::Config {
     }
 }
 
+/// Extracts the plain IP from a `SessionTarget` built by this module — always
+/// `TcpStream`/`UdpStream(SealedHost::Plain(IpOrHost::Ip(_)))`, since that's the only
+/// shape `bridge_target`/`wg_target` are ever constructed in (see `default_bridge_target`,
+/// `default_wg_target`, and the `SocketAddr`-only TOML `target`/`bridge_target`/`wg_target` fields).
+pub(super) fn ip_of(target: &SessionTarget) -> IpAddr {
+    match target {
+        SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(addr)))
+        | SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(addr))) => addr.ip(),
+        other => unreachable!("bridge/wg targets are always plain IP sockets, got {other:?}"),
+    }
+}
+
 pub fn convert_destinations(
     value: Option<HashMap<String, Destination>>,
+    default_bridge_target: &SessionTarget,
+    default_wg_target: &SessionTarget,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
@@ -647,7 +665,24 @@ pub fn convert_destinations(
         };
 
         let meta = dest.meta.clone().unwrap_or_default();
-        let dest = ConnDestination::new(id.to_string(), dest.address, path, meta);
+        let bridge_target = dest
+            .bridge_target
+            .map(|addr| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(addr))))
+            .unwrap_or_else(|| default_bridge_target.clone());
+        let wg_target = dest
+            .wg_target
+            .map(|addr| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(addr))))
+            .unwrap_or_else(|| default_wg_target.clone());
+        let ping_address = dest.ping_address.unwrap_or_else(|| ip_of(&wg_target));
+        let dest = ConnDestination::new(
+            id.to_string(),
+            dest.address,
+            path,
+            meta,
+            bridge_target,
+            wg_target,
+            ping_address,
+        );
         result.insert(id.to_string(), dest);
     }
     Ok(result)
@@ -656,12 +691,24 @@ pub fn convert_destinations(
 #[cfg(test)]
 mod tests {
     use super::{ChannelAllowlistConfig, Config, Strategy, convert_destinations};
+    use crate::connection::options;
     use crate::hopr::strategy_config::StrategyConfig;
     use edgli::hopr_lib::HopRouting;
     use edgli::hopr_lib::api::types::primitive::prelude::Address;
 
     fn parse(toml: &str) -> Config {
         toml::from_str(toml).expect("valid TOML")
+    }
+
+    fn convert(
+        cfg: &Config,
+    ) -> Result<std::collections::HashMap<String, crate::connection::destination::Destination>, crate::config::Error>
+    {
+        convert_destinations(
+            cfg.destinations.clone(),
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        )
     }
 
     #[test]
@@ -675,7 +722,7 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
 path = { hops = 2 }
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert(&cfg).expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(2).unwrap());
     }
@@ -690,21 +737,91 @@ version = 6
 address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
 "#####,
         );
-        let result = convert_destinations(cfg.destinations).expect("should succeed");
+        let result = convert(&cfg).expect("should succeed");
         let d = result.values().next().unwrap();
         assert_eq!(d.routing, HopRouting::try_from(1).unwrap());
     }
 
     #[test]
     fn convert_destinations_empty_map_errors() {
-        let result = convert_destinations(Some(std::collections::HashMap::new()));
+        let result = convert_destinations(
+            Some(std::collections::HashMap::new()),
+            &options::default_bridge_target(),
+            &options::default_wg_target(),
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None);
+        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn convert_destinations_target_overrides_are_applied() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+bridge_target = "10.0.0.5:8000"
+wg_target = "10.0.0.5:51820"
+ping_address = "10.0.0.9"
+"#####,
+        );
+        let result = convert(&cfg).expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(
+            d.bridge_target,
+            edgli::hopr_lib::exports::transport::SessionTarget::TcpStream(
+                edgli::hopr_lib::exports::network::types::types::SealedHost::Plain(
+                    edgli::hopr_lib::exports::network::types::types::IpOrHost::Ip("10.0.0.5:8000".parse().unwrap())
+                )
+            )
+        );
+        assert_eq!(
+            d.wg_target,
+            edgli::hopr_lib::exports::transport::SessionTarget::UdpStream(
+                edgli::hopr_lib::exports::network::types::types::SealedHost::Plain(
+                    edgli::hopr_lib::exports::network::types::types::IpOrHost::Ip("10.0.0.5:51820".parse().unwrap())
+                )
+            )
+        );
+        assert_eq!(d.ping_address, "10.0.0.9".parse::<std::net::IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn convert_destinations_ping_address_defaults_to_overridden_wg_target_ip() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+wg_target = "10.0.0.5:51820"
+"#####,
+        );
+        let result = convert(&cfg).expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(d.ping_address, "10.0.0.5".parse::<std::net::IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn convert_destinations_falls_back_to_global_defaults() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[destinations.Germany]
+address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
+"#####,
+        );
+        let result = convert(&cfg).expect("should succeed");
+        let d = result.values().next().unwrap();
+        assert_eq!(d.bridge_target, options::default_bridge_target());
+        assert_eq!(d.wg_target, options::default_wg_target());
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -60,10 +60,11 @@ pub(super) enum Capability {
     NoRateControl,
 }
 
+// Session targets are configured per destination (`destinations.<id>.bridge_target`/`wg_target`);
+// only the capabilities remain global.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(super) struct ConnectionProtocol {
     pub(super) capabilities: Option<Vec<Capability>>,
-    pub(super) target: Option<SocketAddr>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -237,31 +238,17 @@ fn apply_session_surb(cfg: Option<SessionSurbConfig>, def: options::SessionSurbO
 impl From<Option<Connection>> for options::Options {
     fn from(conn: Option<Connection>) -> Self {
         let connection = conn.as_ref();
-        let bridge_target = connection
-            .and_then(|c| c.bridge.as_ref())
-            .and_then(|b| b.target)
-            .map(|socket| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(options::default_bridge_target());
         let bridge_caps = connection
             .and_then(|c| c.bridge.as_ref())
             .and_then(|b| b.capabilities.clone())
             .unwrap_or(Connection::default_bridge_capabilities());
-        let params_bridge = options::SessionParameters::new(bridge_target, to_flags(bridge_caps));
-
-        let wg_target = connection
-            .and_then(|c| c.wg.as_ref())
-            .and_then(|w| w.target)
-            .map(|socket| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(socket))))
-            .unwrap_or(options::default_wg_target());
         let wg_caps = connection
             .and_then(|c| c.wg.as_ref())
             .and_then(|w| w.capabilities.clone())
             .unwrap_or(Connection::default_wg_capabilities());
-        let params_wg = options::SessionParameters::new(wg_target, to_flags(wg_caps));
-
         let sessions = options::Sessions {
-            bridge: params_bridge,
-            wg: params_wg,
+            bridge_capabilities: to_flags(bridge_caps),
+            wg_capabilities: to_flags(wg_caps),
         };
 
         let def_opts = ping::Options::default();
@@ -418,7 +405,7 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
                     if k == "bridge" || k == "wg" {
                         if let Some(prot) = v.as_table() {
                             for (k2, _) in prot.iter() {
-                                if k2 == "capabilities" || k2 == "target" {
+                                if k2 == "capabilities" {
                                     continue;
                                 }
                                 wrong.push(format!("connection.{k}.{k2}"));
@@ -617,11 +604,7 @@ impl TryFrom<Config> for config::Config {
         if connection.surb_balancing.ping.enabled != connection.surb_balancing.main.enabled {
             return Err(config::Error::SurbBalancingMismatch);
         }
-        let destinations = convert_destinations(
-            value.destinations,
-            &connection.sessions.bridge.target,
-            &connection.sessions.wg.target,
-        )?;
+        let destinations = convert_destinations(value.destinations)?;
         let wireguard = value.wireguard.into();
         let blokli = value.blokli.into();
         let strategy = value.strategy.into();
@@ -637,8 +620,6 @@ impl TryFrom<Config> for config::Config {
 
 pub fn convert_destinations(
     value: Option<HashMap<String, Destination>>,
-    default_bridge_target: &SessionTarget,
-    default_wg_target: &SessionTarget,
 ) -> Result<HashMap<String, ConnDestination>, config::Error> {
     let config_dests = value.ok_or(config::Error::NoDestinations)?;
     if config_dests.is_empty() {
@@ -656,11 +637,11 @@ pub fn convert_destinations(
         let bridge_target = dest
             .bridge_target
             .map(|addr| SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(addr))))
-            .unwrap_or_else(|| default_bridge_target.clone());
+            .unwrap_or_else(options::default_bridge_target);
         let wg_target = dest
             .wg_target
             .map(|addr| SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(addr))))
-            .unwrap_or_else(|| default_wg_target.clone());
+            .unwrap_or_else(options::default_wg_target);
         let ping_address = dest
             .ping_address
             .or_else(|| dest.wg_target.map(|addr| addr.ip()))
@@ -695,11 +676,7 @@ mod tests {
         cfg: &Config,
     ) -> Result<std::collections::HashMap<String, crate::connection::destination::Destination>, crate::config::Error>
     {
-        convert_destinations(
-            cfg.destinations.clone(),
-            &options::default_bridge_target(),
-            &options::default_wg_target(),
-        )
+        convert_destinations(cfg.destinations.clone())
     }
 
     #[test]
@@ -735,17 +712,13 @@ address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739"
 
     #[test]
     fn convert_destinations_empty_map_errors() {
-        let result = convert_destinations(
-            Some(std::collections::HashMap::new()),
-            &options::default_bridge_target(),
-            &options::default_wg_target(),
-        );
+        let result = convert_destinations(Some(std::collections::HashMap::new()));
         assert!(result.is_err());
     }
 
     #[test]
     fn convert_destinations_none_errors() {
-        let result = convert_destinations(None, &options::default_bridge_target(), &options::default_wg_target());
+        let result = convert_destinations(None);
         assert!(result.is_err());
     }
 
@@ -800,7 +773,26 @@ wg_target = "10.0.0.5:51820"
     }
 
     #[test]
-    fn convert_destinations_falls_back_to_global_defaults() {
+    fn wrong_keys_flags_global_connection_targets() {
+        let table: toml::Table = toml::from_str(
+            r#####"
+version = 6
+
+[connection.bridge]
+target = "10.0.0.5:8000"
+
+[connection.wg]
+target = "10.0.0.5:51820"
+"#####,
+        )
+        .expect("valid TOML");
+        let mut wrong = super::wrong_keys(&table);
+        wrong.sort();
+        assert_eq!(wrong, vec!["connection.bridge.target", "connection.wg.target"]);
+    }
+
+    #[test]
+    fn convert_destinations_falls_back_to_default_targets() {
         let cfg = parse(
             r#####"
 version = 6

--- a/gnosis_vpn-lib/src/connection/destination.rs
+++ b/gnosis_vpn-lib/src/connection/destination.rs
@@ -1,9 +1,11 @@
 pub use edgli::hopr_lib::HopRouting;
 pub use edgli::hopr_lib::api::types::primitive::prelude::Address;
+use edgli::hopr_lib::exports::transport::SessionTarget;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 use std::fmt::{self, Display};
+use std::net::IpAddr;
 
 use crate::log_output;
 use crate::serde_utils;
@@ -15,15 +17,33 @@ pub struct Destination {
     #[serde(with = "serde_utils::address")]
     pub address: Address,
     pub routing: HopRouting,
+    /// Exit-side address the ephemeral bridge session connects to.
+    pub bridge_target: SessionTarget,
+    /// Exit-side address the persistent wg (main tunnel) session connects to.
+    pub wg_target: SessionTarget,
+    /// Address pinged through the tunnel to validate connectivity/health.
+    pub ping_address: IpAddr,
 }
 
 impl Destination {
-    pub fn new(id: String, address: Address, routing: HopRouting, meta: HashMap<String, String>) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        address: Address,
+        routing: HopRouting,
+        meta: HashMap<String, String>,
+        bridge_target: SessionTarget,
+        wg_target: SessionTarget,
+        ping_address: IpAddr,
+    ) -> Self {
         Self {
             id,
             address,
             routing,
             meta,
+            bridge_target,
+            wg_target,
+            ping_address,
         }
     }
 

--- a/gnosis_vpn-lib/src/connection/destination.rs
+++ b/gnosis_vpn-lib/src/connection/destination.rs
@@ -26,7 +26,6 @@ pub struct Destination {
 }
 
 impl Destination {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         address: Address,

--- a/gnosis_vpn-lib/src/connection/down/runner.rs
+++ b/gnosis_vpn-lib/src/connection/down/runner.rs
@@ -97,7 +97,7 @@ async fn open_bridge_session(
     };
     hopr.open_session(
         down.destination.address,
-        options.sessions.bridge.target.clone(),
+        down.destination.bridge_target.clone(),
         Some(1),
         Some(1),
         cfg.clone(),

--- a/gnosis_vpn-lib/src/connection/down/runner.rs
+++ b/gnosis_vpn-lib/src/connection/down/runner.rs
@@ -88,7 +88,7 @@ async fn open_bridge_session(
     surb: SurbParams,
 ) -> Result<SessionClientMetadata, HoprError> {
     let cfg = HoprSessionClientConfig {
-        capabilities: options.sessions.bridge.capabilities,
+        capabilities: options.sessions.bridge_capabilities,
         forward_path: down.destination.routing,
         return_path: down.destination.routing,
         always_max_out_surbs: surb.always_max_out_surbs,

--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -7,7 +7,7 @@ use human_bandwidth::re::bandwidth::Bandwidth;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use crate::ping;
@@ -23,9 +23,13 @@ pub fn default_bridge_target() -> SessionTarget {
 
 pub fn default_wg_target() -> SessionTarget {
     SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
-        [172, 30, 0, 1],
+        default_wg_ip(),
         51820,
     )))))
+}
+
+pub fn default_wg_ip() -> IpAddr {
+    IpAddr::from(Ipv4Addr::new(172, 30, 0, 1))
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -12,8 +12,7 @@ use std::time::Duration;
 
 use crate::ping;
 
-// Shared by all config versions that build a `Sessions` default — also the fallback
-// target for destinations that don't override their bridge/wg address.
+// Fallback targets for destinations that don't set `bridge_target`/`wg_target`.
 pub fn default_bridge_target() -> SessionTarget {
     SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
         [172, 30, 0, 1],
@@ -67,19 +66,13 @@ pub struct HealthCheckIntervals {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Sessions {
-    pub bridge: SessionParameters,
-    pub wg: SessionParameters,
+    pub bridge_capabilities: SessionCapabilities,
+    pub wg_capabilities: SessionCapabilities,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Timeouts {
     pub http: Duration,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SessionParameters {
-    pub target: SessionTarget,
-    pub capabilities: SessionCapabilities,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -97,12 +90,6 @@ pub struct SurbBalancing {
     pub main: SessionSurbOptions,
     pub bridge: SessionSurbOptions,
     pub health_check: SessionSurbOptions,
-}
-
-impl SessionParameters {
-    pub fn new(target: SessionTarget, capabilities: SessionCapabilities) -> Self {
-        Self { target, capabilities }
-    }
 }
 
 impl SessionSurbOptions {

--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -1,14 +1,32 @@
 pub const DEFAULT_PATH_PLANNER_MIN_ACK_RATE: f64 = 0.1;
 
 use bytesize::ByteSize;
+use edgli::hopr_lib::exports::network::types::types::{IpOrHost, SealedHost};
 use edgli::hopr_lib::exports::transport::{SessionCapabilities, SessionTarget, SurbBalancerConfig};
 use human_bandwidth::re::bandwidth::Bandwidth;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::ping;
+
+// Shared by all config versions that build a `Sessions` default — also the fallback
+// target for destinations that don't override their bridge/wg address.
+pub fn default_bridge_target() -> SessionTarget {
+    SessionTarget::TcpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
+        [172, 30, 0, 1],
+        8000,
+    )))))
+}
+
+pub fn default_wg_target() -> SessionTarget {
+    SessionTarget::UdpStream(SealedHost::Plain(IpOrHost::Ip(SocketAddr::from((
+        [172, 30, 0, 1],
+        51820,
+    )))))
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Options {

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -146,7 +146,11 @@ impl Runner {
 
         // 10. verify tunnel with ping — give it some leeway with 5 retries
         let _ = results_sender.send(progress(Progress::Ping)).await;
-        let round_trip_time = request_ping(&self.options.ping_options, 5, &results_sender).await?;
+        let ping_options = ping::Options {
+            address: self.destination.ping_address,
+            ..self.options.ping_options.clone()
+        };
+        let round_trip_time = request_ping(&ping_options, 5, &results_sender).await?;
 
         // 11. adjust to main session
         let _ = results_sender
@@ -206,7 +210,7 @@ async fn open_bridge_session(
         tracing::debug!(%destination, "attempting to open bridge session");
         hopr.open_session(
             destination.address,
-            options.sessions.bridge.target.clone(),
+            destination.bridge_target.clone(),
             Some(1),
             Some(1),
             cfg.clone(),
@@ -287,7 +291,7 @@ async fn open_ping_session(
         tracing::debug!(%destination, "attempting to open ping session");
         hopr.open_session(
             destination.address,
-            options.sessions.wg.target.clone(),
+            destination.wg_target.clone(),
             None,
             None,
             cfg.clone(),

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -194,7 +194,7 @@ async fn open_bridge_session(
     results_sender: &mpsc::Sender<Results>,
 ) -> Result<SessionClientMetadata, HoprError> {
     let cfg = HoprSessionClientConfig {
-        capabilities: options.sessions.bridge.capabilities,
+        capabilities: options.sessions.bridge_capabilities,
         forward_path: destination.routing,
         return_path: destination.routing,
         always_max_out_surbs: surb.always_max_out_surbs,
@@ -280,7 +280,7 @@ async fn open_ping_session(
     results_sender: &mpsc::Sender<Results>,
 ) -> Result<SessionClientMetadata, HoprError> {
     let cfg = HoprSessionClientConfig {
-        capabilities: options.sessions.wg.capabilities,
+        capabilities: options.sessions.wg_capabilities,
         forward_path: destination.routing,
         return_path: destination.routing,
         always_max_out_surbs: surb.always_max_out_surbs,

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -883,7 +883,7 @@ impl Core {
                     );
                     log_output::print_session_established(route.as_str());
                     self.spawn_session_monitoring(session, results_sender);
-                    self.spawn_tunnel_ping_probe(results_sender);
+                    self.spawn_tunnel_ping_probe(conn.destination.clone(), results_sender);
                     self.cancel_announced_peers.cancel();
                     self.cancel_announced_peers = self.cancel_on_shutdown.child_token();
                     self.spawn_announced_peers(results_sender, Duration::from_secs(10));
@@ -1642,14 +1642,14 @@ impl Core {
         }
     }
 
-    fn spawn_tunnel_ping_probe(&self, results_sender: &mpsc::Sender<Results>) {
+    fn spawn_tunnel_ping_probe(&self, destination: Destination, results_sender: &mpsc::Sender<Results>) {
         let interval = self.config.connection.health_check_intervals.tunnel_ping;
         let cancel = self.cancel_connection.clone();
         let results_sender = results_sender.clone();
         tokio::spawn(async move {
             cancel
                 .run_until_cancelled(async move {
-                    runner::tunnel_ping_loop(interval, results_sender).await;
+                    runner::tunnel_ping_loop(interval, destination, results_sender).await;
                 })
                 .await
         });

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -883,7 +883,7 @@ impl Core {
                     );
                     log_output::print_session_established(route.as_str());
                     self.spawn_session_monitoring(session, results_sender);
-                    self.spawn_tunnel_ping_probe(conn.destination.clone(), results_sender);
+                    self.spawn_tunnel_ping_probe(conn.destination.ping_address, results_sender);
                     self.cancel_announced_peers.cancel();
                     self.cancel_announced_peers = self.cancel_on_shutdown.child_token();
                     self.spawn_announced_peers(results_sender, Duration::from_secs(10));
@@ -1642,14 +1642,14 @@ impl Core {
         }
     }
 
-    fn spawn_tunnel_ping_probe(&self, destination: Destination, results_sender: &mpsc::Sender<Results>) {
+    fn spawn_tunnel_ping_probe(&self, ping_address: std::net::IpAddr, results_sender: &mpsc::Sender<Results>) {
         let interval = self.config.connection.health_check_intervals.tunnel_ping;
         let cancel = self.cancel_connection.clone();
         let results_sender = results_sender.clone();
         tokio::spawn(async move {
             cancel
                 .run_until_cancelled(async move {
-                    runner::tunnel_ping_loop(interval, destination, results_sender).await;
+                    runner::tunnel_ping_loop(interval, ping_address, results_sender).await;
                 })
                 .await
         });

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -265,11 +265,11 @@ pub(crate) async fn monitor_session(
 
 pub(crate) async fn tunnel_ping_loop(
     interval: Duration,
-    destination: connection::destination::Destination,
+    ping_address: std::net::IpAddr,
     sender: mpsc::Sender<Results>,
 ) {
     let ping_opts = ping::Options {
-        address: destination.ping_address,
+        address: ping_address,
         seq_count: 1,
         ..Default::default()
     };

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -263,8 +263,13 @@ pub(crate) async fn monitor_session(
     let _ = results_sender.send(Results::SessionMonitorFailed).await;
 }
 
-pub(crate) async fn tunnel_ping_loop(interval: Duration, sender: mpsc::Sender<Results>) {
+pub(crate) async fn tunnel_ping_loop(
+    interval: Duration,
+    destination: connection::destination::Destination,
+    sender: mpsc::Sender<Results>,
+) {
     let ping_opts = ping::Options {
+        address: destination.ping_address,
         seq_count: 1,
         ..Default::default()
     };

--- a/gnosis_vpn-lib/src/event/mod.rs
+++ b/gnosis_vpn-lib/src/event/mod.rs
@@ -57,9 +57,9 @@ pub enum RootToWorker {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum WorkerToRoot {
     /// Response to a socket command
-    Response { resp: Response, id: u64 },
+    Response { resp: Box<Response>, id: u64 },
     /// Request to root execution
-    RequestToRoot(RequestToRoot),
+    RequestToRoot(Box<RequestToRoot>),
 }
 
 /// Runner requesting root command and usually waiting for response

--- a/gnosis_vpn-lib/src/route_health.rs
+++ b/gnosis_vpn-lib/src/route_health.rs
@@ -900,7 +900,7 @@ impl HealthSession {
         let health_surb =
             surb_config_for(&options.surb_balancing.health_check).map_err(|e| HoprError::Session(e.to_string()))?;
         let cfg = HoprSessionClientConfig {
-            capabilities: options.sessions.bridge.capabilities,
+            capabilities: options.sessions.bridge_capabilities,
             forward_path: destination.routing,
             return_path: destination.routing,
             always_max_out_surbs: health_surb.always_max_out_surbs,

--- a/gnosis_vpn-lib/src/route_health.rs
+++ b/gnosis_vpn-lib/src/route_health.rs
@@ -909,13 +909,7 @@ impl HealthSession {
         };
         tracing::debug!(%destination, "opening TCP session for health check");
         let meta = hopr
-            .open_session(
-                destination.address,
-                options.sessions.bridge.target.clone(),
-                None,
-                None,
-                cfg,
-            )
+            .open_session(destination.address, destination.bridge_target.clone(), None, None, cfg)
             .await?;
         Ok(Self {
             hopr,
@@ -1193,12 +1187,16 @@ mod tests {
 
     fn backoff_at(failures: u32) -> Duration {
         use crate::connection::destination::{Destination, HopRouting};
+        use crate::connection::options;
         use tokio_util::sync::CancellationToken;
         let dest = Destination::new(
             "test".to_string(),
             addr(1),
             HopRouting::try_from(1).unwrap(),
             Default::default(),
+            options::default_bridge_target(),
+            options::default_wg_target(),
+            std::net::IpAddr::from([172, 30, 0, 1]),
         );
         let mut rh = RouteHealth::new(&dest, false, false, CancellationToken::new());
         rh.exit_failures = failures;

--- a/gnosis_vpn-root/src/main.rs
+++ b/gnosis_vpn-root/src/main.rs
@@ -1008,8 +1008,8 @@ impl DaemonState {
             exitcode::DATAERR
         })?;
         match cmd {
-            WorkerToRoot::Response { id, resp } => self.incoming_worker_response(id, resp).await,
-            WorkerToRoot::RequestToRoot(request) => self.incoming_worker_request(request).await,
+            WorkerToRoot::Response { id, resp } => self.incoming_worker_response(id, *resp).await,
+            WorkerToRoot::RequestToRoot(request) => self.incoming_worker_request(*request).await,
         }
     }
 

--- a/gnosis_vpn-worker/src/main.rs
+++ b/gnosis_vpn-worker/src/main.rs
@@ -407,7 +407,7 @@ impl State {
                         let res_recv = resp_recv.await;
                         match res_recv {
                             Ok(resp) => {
-                                send_to_root(Box::new(WorkerToRoot::Response { id, resp }), &mut self.root_socket_writer).await?;
+                                send_to_root(Box::new(WorkerToRoot::Response { id, resp: Box::new(resp) }), &mut self.root_socket_writer).await?;
                             }
                             Err(err) => {
                                 tracing::warn!(error = ?err, "core-to-worker receiver unexpectedly closed while awaiting response for command from root");
@@ -426,7 +426,7 @@ impl State {
                 Some(event) = core_to_worker_receiver.recv() => match event {
                     CoreToWorker::RequestToRoot(req) => {
                         tracing::debug!(?req, "incoming request to root from core");
-                        send_to_root(Box::new(WorkerToRoot::RequestToRoot(req)), &mut self.root_socket_writer).await?;
+                        send_to_root(Box::new(WorkerToRoot::RequestToRoot(Box::new(req))), &mut self.root_socket_writer).await?;
                     }
                 },
                 Some(_) = self.core_task.join_next() => {


### PR DESCRIPTION
… destination

Different exit operators can run their gnosis-vpn server on a different local address/port, so bridge_target, wg_target, and ping_address are now resolved per destination (config v6 only), falling back to the existing global defaults. ping_address further defaults to its destination's own wg_target IP rather than the old fixed 10.128.0.1, and can be overridden to diverge.