### PR TITLE
feat: Add Blokli DNS override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=2090e068da2b819c8f05d745222f422942538b12#2090e068da2b819c8f05d745222f422942538b12"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=634a1be5ea81719cdbbdb63046fc9a97c56765e7#634a1be5ea81719cdbbdb63046fc9a97c56765e7"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.1", features = ["derive", "env"] }
 clap_complete = "~4.6.5"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "2090e068da2b819c8f05d745222f422942538b12", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "634a1be5ea81719cdbbdb63046fc9a97c56765e7", features = [
   "blokli",
   "telemetry",
 ] }

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -67,13 +67,15 @@ impl Runner {
     }
 
     async fn run(&self, results_sender: mpsc::Sender<Results>) -> Result<SessionClientMetadata, Error> {
-        // 1. resolve blokli ips — use cached IPs when killswitch is active (DNS unreachable)
+        // 1. determine the blokli ips to exempt from the killswitch, which blocks DNS while up
         let _ = results_sender.send(progress(Progress::ResolveBlokliIps)).await;
         let blokli_url = hopr::blokli_url(self.worker_params.blokli_url());
-        let blokli_ips = if self.prev_conn.blokli_ips.is_empty() {
-            remote_data::resolve_ips(&blokli_url).await?
-        } else {
-            self.prev_conn.blokli_ips.clone()
+        let blokli_ips = match self.worker_params.pinned_blokli_ip() {
+            // The Blokli client talks to the pinned address instead of resolving the host, so the
+            // killswitch has to exempt exactly that address rather than whatever DNS returns now.
+            Some(ip) => vec![ip],
+            None if !self.prev_conn.blokli_ips.is_empty() => self.prev_conn.blokli_ips.clone(),
+            None => remote_data::resolve_ips(&blokli_url).await?,
         };
 
         // 2. generate wg keys

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -494,7 +494,7 @@ async fn run_hopr(
     tracing::debug!("starting hopr runner");
     let cfg = worker_params.to_config(safe_module, path_planner_min_ack_rate).await?;
     let keys = worker_params.calc_keys().await?;
-    let blokli_url = worker_params.blokli_url();
+    let blokli_endpoint = worker_params.blokli_endpoint();
     let sender = results_sender.clone();
     let visitor = move |state| {
         if let Err(err) = sender.try_send(Results::HoprConstruction(state)) {
@@ -502,7 +502,7 @@ async fn run_hopr(
         }
     };
 
-    Hopr::new(cfg, keys, blokli_url, blokli_config.into(), visitor)
+    Hopr::new(cfg, keys, blokli_endpoint, blokli_config.into(), visitor)
         .await
         .map_err(Error::from)
 }
@@ -527,10 +527,10 @@ async fn run_create_incentive_operations(
     blokli_config: BlockchainConnectorConfig,
     results_sender: mpsc::Sender<Results>,
 ) -> Result<Arc<dyn IncentiveOperations>, Error> {
-    let blokli_provider = worker_params.blokli_url();
+    let blokli_endpoint = worker_params.blokli_endpoint();
     let chain_key = worker_params.calc_keys().await?.chain_key;
     (|| async {
-        let ops = make_incentive_operations(blokli_provider.clone(), &chain_key, Some(blokli_config))
+        let ops = make_incentive_operations(blokli_endpoint.clone(), &chain_key, Some(blokli_config))
             .await
             .map_err(|e| Error::IncentiveOperationsCreation(e.to_string()))?;
         Ok(Arc::from(ops))

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -1,5 +1,5 @@
 use bytesize::ByteSize;
-use edgli::{BlockchainConnectorConfig, EdgeNodeApi, EdgliInitState};
+use edgli::{BlockchainConnectorConfig, BlokliEndpoint, EdgeNodeApi, EdgliInitState};
 use edgli::{
     Edgli,
     hopr_lib::{
@@ -50,7 +50,7 @@ impl Hopr {
     pub async fn new(
         cfg: edgli::hopr_lib::config::HoprLibConfig,
         keys: edgli::hopr_lib::HoprKeys,
-        blokli_url: Option<url::Url>,
+        blokli_endpoint: BlokliEndpoint,
         blokli_config: BlockchainConnectorConfig,
         init_visitor: impl Fn(EdgliInitState) + Send + 'static,
     ) -> Result<Self, HoprError> {
@@ -58,8 +58,7 @@ impl Hopr {
         let edge_node = Edgli::new(
             cfg,
             keys,
-            blokli_url.map(|u| u.to_string()),
-            None, // blokli_dns_override
+            blokli_endpoint,
             Some(blokli_config),
             false, // probe_local_addresses: filter out non-public peer addresses
             init_visitor,

--- a/gnosis_vpn-lib/src/worker_params.rs
+++ b/gnosis_vpn-lib/src/worker_params.rs
@@ -1,19 +1,21 @@
 use edgli::blokli::{IncentiveOperations, make_incentive_operations};
 use edgli::hopr_lib::HoprKeys;
 use edgli::hopr_lib::config::HoprLibConfig;
+use edgli::{BlokliDnsOverride, BlokliEndpoint};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use url::Url;
 
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::compat::SafeModule;
 use crate::hopr::blokli_config::BlokliConfig;
-use crate::hopr::{config, identity};
+use crate::hopr::{self, config, identity};
+use crate::remote_data;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -37,6 +39,8 @@ pub struct WorkerParams {
     allow_insecure: bool,
     allow_experimental: bool,
     blokli_url: Option<Url>,
+    /// Address the Blokli host resolved to at service startup, see [`WorkerParams::resolve_blokli_ip`].
+    resolved_blokli_ip: Option<Ipv4Addr>,
     state_home: PathBuf,
     cached_blokli_ips: Vec<Ipv4Addr>,
 }
@@ -64,6 +68,7 @@ impl WorkerParams {
             allow_insecure,
             allow_experimental,
             blokli_url,
+            resolved_blokli_ip: None,
             state_home,
             cached_blokli_ips: Vec::new(),
         }
@@ -183,8 +188,8 @@ impl WorkerParams {
     ) -> Result<Arc<dyn IncentiveOperations>, Error> {
         let keys = self.calc_keys().await?;
         let private_key = keys.chain_key;
-        let url = self.blokli_url();
-        let ops = make_incentive_operations(url, &private_key, Some(config.into()))
+        let endpoint = self.blokli_endpoint();
+        let ops = make_incentive_operations(endpoint, &private_key, Some(config.into()))
             .await
             .map_err(|e| Error::BlokliCreation(e.to_string()))?;
         Ok(Arc::from(ops))
@@ -200,6 +205,44 @@ impl WorkerParams {
 
     pub fn blokli_url(&self) -> Option<Url> {
         self.blokli_url.clone()
+    }
+
+    /// Resolves the Blokli host once, so later Blokli traffic needs no DNS lookup.
+    ///
+    /// Called at service startup while DNS is still reachable: an active killswitch blocks DNS
+    /// for the rest of the session, which would otherwise leave the Blokli client unable to
+    /// resolve its endpoint. Leaves the address unset on failure, falling back to system DNS.
+    pub async fn resolve_blokli_ip(&mut self) {
+        let url = hopr::blokli_url(self.blokli_url());
+        match remote_data::resolve_ips(&url).await.map(|ips| ips.first().copied()) {
+            Ok(Some(ip)) => {
+                tracing::info!(%url, %ip, "resolved blokli host - pinning it for this session");
+                self.resolved_blokli_ip = Some(ip);
+            }
+            Ok(None) => tracing::warn!(%url, "blokli host has no IPv4 address - falling back to system DNS"),
+            Err(error) => {
+                tracing::warn!(%url, %error, "failed to resolve blokli host - falling back to system DNS")
+            }
+        }
+    }
+
+    /// The address the Blokli host is pinned to, if it is known.
+    ///
+    /// Prefers the address resolved at startup and falls back to a cached one from an earlier
+    /// connection, which covers a worker restart while the killswitch blocks DNS.
+    pub fn pinned_blokli_ip(&self) -> Option<Ipv4Addr> {
+        self.resolved_blokli_ip
+            .or_else(|| self.cached_blokli_ips.first().copied())
+    }
+
+    /// The Blokli endpoint to talk to, including how its host is resolved.
+    pub fn blokli_endpoint(&self) -> BlokliEndpoint {
+        let endpoint = BlokliEndpoint::new(hopr::blokli_url(self.blokli_url()));
+        match self.pinned_blokli_ip() {
+            // A `None` port keeps the endpoint URL's port, which is what the IP was resolved for.
+            Some(ip) => endpoint.with_dns_override(BlokliDnsOverride::new(IpAddr::V4(ip), None)),
+            None => endpoint,
+        }
     }
 
     pub fn state_home(&self) -> PathBuf {
@@ -232,5 +275,96 @@ fn log_path_diagnostics(path: &std::path::Path) {
             path = ?parent,
             "pass file parent directory metadata"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(blokli_url: Option<Url>) -> WorkerParams {
+        WorkerParams::new(
+            None,
+            None,
+            ConfigFileMode::Generated,
+            false,
+            false,
+            blokli_url,
+            PathBuf::from("/tmp/gnosisvpn"),
+        )
+    }
+
+    fn url(raw: &str) -> Option<Url> {
+        Some(raw.parse().unwrap())
+    }
+
+    #[test]
+    fn blokli_endpoint_uses_system_dns_until_the_host_is_resolved() {
+        let endpoint = params(None).blokli_endpoint();
+        assert_eq!(endpoint.url, *edgli::DEFAULT_BLOKLI_URL);
+        assert_eq!(endpoint.dns_override, None);
+    }
+
+    #[test]
+    fn blokli_endpoint_keeps_configured_url() {
+        let configured = url("https://blokli.example.com/").unwrap();
+        let endpoint = params(Some(configured.clone())).blokli_endpoint();
+        assert_eq!(endpoint.url, configured);
+    }
+
+    #[tokio::test]
+    async fn resolving_the_host_pins_the_endpoint_to_its_address() {
+        let mut params = params(url("http://localhost:3002"));
+        params.resolve_blokli_ip().await;
+
+        assert_eq!(params.pinned_blokli_ip(), Some(Ipv4Addr::LOCALHOST));
+        // A `None` port leaves the endpoint URL's port in place.
+        assert_eq!(
+            params.blokli_endpoint().dns_override,
+            Some(BlokliDnsOverride::new(IpAddr::V4(Ipv4Addr::LOCALHOST), None))
+        );
+    }
+
+    /// Blokli stays reachable via system DNS when startup resolution fails, rather than the
+    /// service refusing to start.
+    #[tokio::test]
+    async fn an_unresolvable_host_leaves_the_endpoint_on_system_dns() {
+        let mut params = params(url("file:///no-host-here"));
+        params.resolve_blokli_ip().await;
+
+        assert_eq!(params.pinned_blokli_ip(), None);
+        assert_eq!(params.blokli_endpoint().dns_override, None);
+    }
+
+    /// A worker restarting while the killswitch blocks DNS gets no startup resolution, so the
+    /// IP cached during the previous connection - the one the killswitch exempts - pins the host.
+    #[test]
+    fn a_cached_ip_pins_the_endpoint_when_startup_resolution_produced_nothing() {
+        let mut params = params(None);
+        params.set_cached_blokli_ips(vec![Ipv4Addr::new(203, 0, 113, 7), Ipv4Addr::new(203, 0, 113, 8)]);
+
+        assert_eq!(params.pinned_blokli_ip(), Some(Ipv4Addr::new(203, 0, 113, 7)));
+    }
+
+    #[tokio::test]
+    async fn the_startup_address_wins_over_a_cached_ip() {
+        let mut params = params(url("http://localhost:3002"));
+        params.resolve_blokli_ip().await;
+        params.set_cached_blokli_ips(vec![Ipv4Addr::new(203, 0, 113, 7)]);
+
+        assert_eq!(params.pinned_blokli_ip(), Some(Ipv4Addr::LOCALHOST));
+    }
+
+    /// `WorkerParams` is serialized to hand it from the root process to the worker, so the
+    /// address resolved on the root side has to survive that hop.
+    #[tokio::test]
+    async fn the_pinned_address_survives_a_serde_roundtrip() {
+        let mut params = params(url("http://localhost:3002"));
+        params.resolve_blokli_ip().await;
+
+        let json = serde_json::to_string(&params).unwrap();
+        let restored: WorkerParams = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.pinned_blokli_ip(), Some(Ipv4Addr::LOCALHOST));
     }
 }

--- a/gnosis_vpn-root/src/main.rs
+++ b/gnosis_vpn-root/src/main.rs
@@ -428,7 +428,7 @@ async fn keep_alive_timer(
 
 async fn daemon(args: cli::Cli) -> Result<(), exitcode::ExitCode> {
     // ensure worker user exists
-    let worker_params = WorkerParams::from(&args);
+    let mut worker_params = WorkerParams::from(&args);
     let input = worker::Input::new(
         args.worker_user.clone(),
         args.worker_binary.clone(),
@@ -453,6 +453,10 @@ async fn daemon(args: cli::Cli) -> Result<(), exitcode::ExitCode> {
 
     let network_info = network_info::NetworkInfo::gather().await;
     tracing::info!(%network_info, "host network info");
+
+    // Resolve the blokli host while DNS is still reachable - an enabled killswitch blocks DNS
+    // for the rest of the session, including for workers started after that point.
+    worker_params.resolve_blokli_ip().await;
 
     // Write root pidfile for the newsyslog service to send signals to
     write_pidfile(&args.pid_file).await?;


### PR DESCRIPTION
Currently once the killswitch is active it might happen that DNS fails if the VPN connection is failing, rendering Blokli access not working. This PR fixes that behaviour.