### PR TITLE
feat(hopr): integrate latest edge-client with robust flow control and tokio_unstable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,10 +10,29 @@ CFLAGS   = "-O3 -ffunction-sections -fdata-sections -fPIC"
 CPPFLAGS = "-O3 -ffunction-sections -fdata-sections -fPIC"
 LDFLAGS  = "-O3 -ffunction-sections -fdata-sections -fPIC"
 
+# Build the workspace (and the hopr crates pulled via edgli) with
+# `--cfg tokio_unstable` so Tokio's improved cooperative yielding is active on the
+# async hot paths — the build that produced the validated multi-hop throughput.
+# `--check-cfg` keeps the flag from tripping `-D warnings`. NOTE: Cargo does NOT
+# merge `[build]` with target-specific rustflags — a matching `[target.<triple>]`
+# table wins outright — so the flag is repeated in the aarch64 table below. The
+# Nix shells set CARGO_BUILD_RUSTFLAGS (which replaces `[build]`); flake.nix
+# re-appends the tokio flags there so nix/CI builds keep it too.
+# The `=`-joined single-token forms are order-independent so treefmt's
+# `taplo -o reorder_arrays=true` cannot corrupt a flag/value pair by sorting.
+[build]
+rustflags = ["--cfg=tokio_unstable", "--check-cfg=cfg(tokio_unstable)"]
+
 # Enable hardware AES intrinsics on Apple Silicon — selects aes::armv8 backend
 # at compile time instead of aes::soft::fixslice. The aes crate v0.8 requires
 # --cfg aes_armv8 (not just target-feature=+aes) to activate the armv8 module.
 # Restricted to aarch64-apple-darwin: Apple Silicon always has the AES crypto
 # extension; aarch64-unknown-linux-* cannot make that guarantee.
 [target.aarch64-apple-darwin]
-rustflags = ["--cfg=aes_armv8", "-Ctarget-feature=+aes,+neon"]
+# Repeats the tokio_unstable flags because this target table replaces `[build]`.
+rustflags = [
+  "--cfg=aes_armv8",
+  "--cfg=tokio_unstable",
+  "--check-cfg=cfg(tokio_unstable)",
+  "-Ctarget-feature=+aes,+neon",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -243,7 +243,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ dependencies = [
  "borsh",
  "k256 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -401,7 +401,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
  "rand 0.8.6",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -501,7 +501,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -610,7 +610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ dependencies = [
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.6",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -743,7 +743,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -779,7 +779,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -867,9 +867,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "aquamarine"
@@ -1163,7 +1172,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -1308,13 +1317,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1660,7 +1669,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -1754,6 +1763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 dependencies = [
  "serde_core",
 ]
@@ -1901,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1911,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1932,14 +1947,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1969,7 +1984,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2771,8 +2786,8 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.3.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=634a1be5ea81719cdbbdb63046fc9a97c56765e7#634a1be5ea81719cdbbdb63046fc9a97c56765e7"
+version = "3.5.0"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7#40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2798,7 +2813,7 @@ dependencies = [
  "signal-hook",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3181,9 +3196,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3206,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3229,15 +3244,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3246,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -3265,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3287,15 +3302,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-time"
@@ -3320,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3402,6 +3417,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360bd2cd76e0cd9032d42cf2922155cecea2685b0cfa4630c3246df030bcfd6"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,7 +3518,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "toml",
@@ -3505,7 +3544,7 @@ dependencies = [
  "notify",
  "rtnetlink 0.21.0",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
@@ -3746,7 +3785,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3772,7 +3811,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3793,7 +3832,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -3815,7 +3854,7 @@ dependencies = [
  "rand 0.9.4",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3841,7 +3880,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -3884,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c76f9c17f903a3a0487c7eb0766914baf94380cd7a9112043310e4bc4dc9547"
+checksum = "1fcb5fdc41eecbf93059fe0e96ee0f8680edce2468cfcdf9a48e7a30fc4c6cf4"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3899,7 +3938,7 @@ dependencies = [
  "multiaddr",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3916,15 +3955,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.22.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3937,7 +3976,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "moka",
  "parking_lot",
  "petgraph",
@@ -3946,7 +3985,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
@@ -3954,25 +3993,25 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3980,7 +4019,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "smart-default",
  "tracing",
  "validator",
@@ -3988,8 +4027,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "4.0.2-rc.9"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4003,7 +4042,7 @@ dependencies = [
  "hopr-api",
  "hopr-network-graph",
  "hopr-transport",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -4011,7 +4050,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "validator",
@@ -4020,40 +4059,40 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4065,7 +4104,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4075,15 +4114,15 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "1.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4097,7 +4136,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4106,7 +4145,7 @@ dependencies = [
  "serde_bytes",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4114,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4123,13 +4162,14 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hopr-strategy"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b7849a82fe53e861a4938d1fab94123a16ba55917ff187de358610c07d599a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4139,8 +4179,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-crypto-packet",
- "hopr-utils",
+ "hopr-utilities 0.4.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4149,15 +4188,16 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "thiserror 2.0.18",
+ "statrs",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.5.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4166,20 +4206,20 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "parking_lot",
  "postcard",
  "redb",
  "strum 0.28.0",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport"
-version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.35.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4191,6 +4231,7 @@ dependencies = [
  "dashmap",
  "futures",
  "futures-time",
+ "futures-timer",
  "halfbrown",
  "hopr-api",
  "hopr-crypto-packet",
@@ -4200,18 +4241,19 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "libp2p",
  "moka",
  "multiaddr",
  "proc-macro-regex",
- "rust-stream-ext-concurrent",
+ "rand 0.10.2",
+ "rand_distr",
  "serde",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio-util",
  "tracing",
  "validator",
@@ -4220,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4230,14 +4272,14 @@ dependencies = [
  "parking_lot",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4245,20 +4287,20 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
  "pin-project",
  "quinn-udp 0.6.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4269,22 +4311,22 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
  "serde",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.24.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4297,7 +4339,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4308,7 +4350,7 @@ dependencies = [
  "serde_repr",
  "smart-default",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4316,12 +4358,12 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "validator",
 ]
 
@@ -4378,7 +4420,7 @@ dependencies = [
  "smart-default",
  "strum 0.28.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "typenum",
  "uuid",
@@ -4386,12 +4428,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-utils"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+name = "hopr-utilities"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95680cead4b551cdeb76b016e99197f17b3528e790d1b37a7978b8e38e5f36b7"
+dependencies = [
+ "auto_impl",
+ "futures",
+ "indexmap 2.14.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-utilities"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
 dependencies = [
  "arrayvec",
  "auto_impl",
+ "const-hex",
  "crossfire",
  "flume",
  "futures",
@@ -4408,9 +4465,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
+ "serde_json",
  "socket2 0.6.4",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4419,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4431,13 +4489,13 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utils",
+ "hopr-utilities 0.5.1",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4985,7 +5043,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -5207,7 +5265,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5241,7 +5299,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.6",
  "rand_core 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "web-time",
 ]
@@ -5276,7 +5334,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.6",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -5315,7 +5373,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -5333,7 +5391,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zeroize",
 ]
@@ -5390,7 +5448,7 @@ dependencies = [
  "rand 0.8.6",
  "snow",
  "static_assertions",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5414,7 +5472,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -5513,7 +5571,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x509-parser",
  "yasna",
 ]
@@ -5542,7 +5600,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -5652,6 +5710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -5799,6 +5867,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.3",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.10.2",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5848,7 +5936,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5975,6 +6063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5986,6 +6083,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6131,7 +6239,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6161,7 +6269,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -6204,7 +6312,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6424,7 +6532,7 @@ checksum = "044b1fa4f259f4df9ad5078e587b208f5d288a25407575fcddb9face30c7c692"
 dependencies = [
  "rand 0.9.4",
  "socket2 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6792,7 +6900,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -6815,7 +6923,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6954,6 +7062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6970,6 +7088,12 @@ checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7258,16 +7382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
-name = "rust-stream-ext-concurrent"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b7b0b486f2712aa8fa4a7b21303d79c60ceca3b11a3e9d82eb7c650bc9c4ff"
-dependencies = [
- "futures",
- "pin-project",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7430,6 +7544,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "salsa20"
@@ -7622,9 +7745,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7671,29 +7794,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -7704,13 +7827,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7896,6 +8019,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834a9952211d4a60ff10ac1d20cc01640a75bdc0a0c688d62f359ea7d17459f3"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8045,6 +8180,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78553aa710187998fc7c7945c18889c59ef199ff7d2146ab90998b431b29eea"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand 0.10.2",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "strobe-rs"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8133,6 +8281,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8240,11 +8399,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -8260,13 +8419,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8364,9 +8523,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -8403,9 +8562,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8415,15 +8574,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -8823,12 +8983,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -9015,6 +9174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -9375,7 +9544,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "3.5.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7#40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a#d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-ctl"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-lib"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-root"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-system_tests"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-worker"
-version = "0.93.1"
+version = "0.94.0"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-ctl"
-version = "0.94.0"
+version = "0.93.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-lib"
-version = "0.94.0"
+version = "0.93.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-root"
-version = "0.94.0"
+version = "0.93.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-system_tests"
-version = "0.94.0"
+version = "0.93.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "gnosis_vpn-worker"
-version = "0.94.0"
+version = "0.93.1"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "LGPL-3.0-only"
-version = "0.94.0"
+version = "0.93.1"
 
 [workspace.metadata.crane]
 name = "gnosis_vpn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.1", features = ["derive", "env"] }
 clap_complete = "~4.6.5"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "LGPL-3.0-only"
-version = "0.93.1"
+version = "0.94.0"
 
 [workspace.metadata.crane]
 name = "gnosis_vpn"
@@ -14,7 +14,7 @@ name = "gnosis_vpn"
 anyhow = { version = "~1.0.103" }
 async-trait = "~0.1.89"
 backon = { version = "~1.6.0" }
-bytesize = "~2.4.0"
+bytesize = "~2.7.0"
 cfg-if = "~1.0.4"
 chrono = { version = "~0.4.45", default-features = false, features = [
   "clock",
@@ -23,14 +23,14 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.1", features = ["derive", "env"] }
 clap_complete = "~4.6.5"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "634a1be5ea81719cdbbdb63046fc9a97c56765e7", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "40a62c7aeb26c92b5e27531a1ed5ca58b335e5f7", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "~1.1.2"
 futures = "~0.3.32"
 futures-util = "~0.3.32"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "~0.1.4"
@@ -54,7 +54,7 @@ serde_with = "~3.21.0"
 tempfile = "~3.27.0"
 thiserror = "~2.0.18"
 tikv-jemallocator = "~0.7.0"
-tokio = { version = "~1.52.3", features = ["full"] }
+tokio = { version = "~1.53.1", features = ["full"] }
 tokio-util = { version = "~0.7.18", features = ["rt"] }
 toml = "~1.1.2"
 tracing = { version = "~0.1.44", features = ["release_max_level_debug"] }

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,16 @@
             }
           );
 
+          # Build with `--cfg tokio_unstable` so Tokio's improved cooperative
+          # yielding is active (the config that produced the validated throughput).
+          # nix-lib's shells/builds set CARGO_BUILD_RUSTFLAGS (linker flag), which
+          # *replaces* `.cargo/config.toml`'s `[build]` table, so append the tokio
+          # flags there to keep them alongside the linker flag. `--check-cfg` keeps
+          # the flag from tripping `-D warnings`.
+          tokioUnstableHook = ''
+            export CARGO_BUILD_RUSTFLAGS="''${CARGO_BUILD_RUSTFLAGS:-} --cfg tokio_unstable --check-cfg cfg(tokio_unstable)"
+          '';
+
           gnosisvpnPackages = import ./nix/gnosisvpn.nix {
             inherit
               lib
@@ -84,6 +94,7 @@
               pkgs
               craneLib
               advisory-db
+              tokioUnstableHook
               ;
           };
 
@@ -162,6 +173,9 @@
             {
               inherit pre-commit-check;
               checks = self.checks.${system};
+
+              # Keep `--cfg tokio_unstable` on interactive `cargo` invocations too.
+              shellHook = tokioUnstableHook;
 
               packages = [
                 pkgs.cargo-machete

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -793,7 +793,7 @@ path_planner_min_ack_rate = {bad}
             target_open_channels: None,
             channel_allowlist: Some(ChannelAllowlistConfig {
                 enabled: true,
-                peers: vec![addr.clone()],
+                peers: vec![addr],
             }),
         });
         let cfg: StrategyConfig = strategy.into();

--- a/gnosis_vpn-lib/src/connection/down/runner.rs
+++ b/gnosis_vpn-lib/src/connection/down/runner.rs
@@ -1,6 +1,7 @@
 //! The runner module for `core::connection::down` struct.
 //! It handles all state transitions and forwards transition events though its channel.
 //! This allows keeping the source of truth for data in `core` and avoiding structs duplication.
+use edgli::FlowControlConfig;
 use edgli::hopr_lib::HoprSessionClientConfig;
 use tokio::sync::mpsc;
 
@@ -93,6 +94,8 @@ async fn open_bridge_session(
         return_path: down.destination.routing,
         always_max_out_surbs: surb.always_max_out_surbs,
         surb_management: surb.management,
+        // Robust tail-tolerance profile for the down-direction data session.
+        flow_control: Some(FlowControlConfig::robust()),
         ..Default::default()
     };
     hopr.open_session(

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -2,6 +2,7 @@
 //! It handles state transitions up until wg tunnel initiation and forwards transition events though its channel.
 //! This allows keeping the source of truth for data in `core` and avoiding structs duplication.
 use backon::{FibonacciBuilder, Retryable};
+use edgli::FlowControlConfig;
 use edgli::hopr_lib::{HoprSessionClientConfig, api::types::internal::protocol::HoprPseudonym};
 use tokio::sync::{mpsc, oneshot};
 
@@ -197,6 +198,9 @@ async fn open_bridge_session(
         return_path: destination.routing,
         always_max_out_surbs: surb.always_max_out_surbs,
         surb_management: surb.management,
+        // Robust tail-tolerance profile: the validated flow-control config for the
+        // throttled / multi-hop paths this data session runs over.
+        flow_control: Some(FlowControlConfig::robust()),
         ..Default::default()
     };
     // Each open_session attempt times out after `initiation_timeout_base × (forward_hops + return_hops + 2)`,
@@ -284,6 +288,8 @@ async fn open_ping_session(
         always_max_out_surbs: surb.always_max_out_surbs,
         surb_management: surb.management,
         pseudonym,
+        // Robust tail-tolerance profile for the WireGuard data session.
+        flow_control: Some(FlowControlConfig::robust()),
     };
     (|| async {
         tracing::debug!(%destination, "attempting to open ping session");

--- a/gnosis_vpn-lib/src/killswitch/macos.rs
+++ b/gnosis_vpn-lib/src/killswitch/macos.rs
@@ -141,10 +141,8 @@ impl Firewall {
         };
         for state in states {
             let is_loopback = state.local_address().map(|a| a.ip().is_loopback()).unwrap_or(true); // keep state if we can't parse it
-            if !is_loopback {
-                if let Err(e) = self.pf.kill_state(&state) {
-                    tracing::warn!(?e, "failed to kill PF state");
-                }
+            if !is_loopback && let Err(e) = self.pf.kill_state(&state) {
+                tracing::warn!(?e, "failed to kill PF state");
             }
         }
     }

--- a/gnosis_vpn-root/src/routing/route_ops_macos.rs
+++ b/gnosis_vpn-root/src/routing/route_ops_macos.rs
@@ -247,14 +247,14 @@ default            10.0.0.1           UGSc                en1
     fn netstat_excluding_returns_first_non_excluded_route() {
         // utun5 is the VPN tunnel; en0 should be returned as the WAN default.
         let result = parse_netstat_default_excluding(NETSTAT_OUTPUT, "utun5");
-        assert_eq!(result, Ok(("en0".to_string(), Some("192.168.1.1".to_string()))));
+        assert_eq!(result.unwrap(), ("en0".to_string(), Some("192.168.1.1".to_string())));
     }
 
     #[test]
     fn netstat_excluding_skips_excluded_iface() {
         // Exclude en0; next non-I default is en1.
         let result = parse_netstat_default_excluding(NETSTAT_OUTPUT, "en0");
-        assert_eq!(result, Ok(("en1".to_string(), Some("10.0.0.1".to_string()))));
+        assert_eq!(result.unwrap(), ("en1".to_string(), Some("10.0.0.1".to_string())));
     }
 
     #[test]
@@ -266,14 +266,14 @@ default            link#18            UCSIg               utun5
 default            192.168.1.1        UGScg               en0
 ";
         let result = parse_netstat_default_excluding(output, "en9");
-        assert_eq!(result, Ok(("en0".to_string(), Some("192.168.1.1".to_string()))));
+        assert_eq!(result.unwrap(), ("en0".to_string(), Some("192.168.1.1".to_string())));
     }
 
     #[test]
     fn netstat_excluding_returns_none_gateway_for_link_local() {
         let output = "default            link#5             UCSg                en0\n";
         let result = parse_netstat_default_excluding(output, "utun5");
-        assert_eq!(result, Ok(("en0".to_string(), None)));
+        assert_eq!(result.unwrap(), ("en0".to_string(), None));
     }
 
     #[test]

--- a/gnosis_vpn-root/src/routing_actor.rs
+++ b/gnosis_vpn-root/src/routing_actor.rs
@@ -181,7 +181,7 @@ impl Actor {
         // if_indextoname already fails, so we emit LinkRemoved with a synthetic
         // "if#N" name. Check whether the resolved WG interface still exists.
         #[cfg(target_os = "macos")]
-        if removed_link.as_ref().map_or(false, |n| n.starts_with("if#")) {
+        if removed_link.as_ref().is_some_and(|n| n.starts_with("if#")) {
             let wg_gone = std::ffi::CString::new(wg_iface.as_str())
                 .map(|name| unsafe { libc::if_nametoindex(name.as_ptr()) } == 0)
                 .unwrap_or(false);

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -15,6 +15,8 @@
   pkgs,
   craneLib,
   advisory-db,
+  # Shell snippet appending `--cfg tokio_unstable` to CARGO_BUILD_RUSTFLAGS.
+  tokioUnstableHook,
 }:
 
 let
@@ -111,6 +113,40 @@ let
       }
     );
 
+  # Flags that activate Tokio's improved cooperative yielding (the config that
+  # produced the validated multi-hop throughput). `--check-cfg` keeps the cfg
+  # from tripping `-D warnings`.
+  tokioUnstableRustflags = "--cfg tokio_unstable --check-cfg cfg(tokio_unstable)";
+
+  # Appends the tokio_unstable flags to CARGO_BUILD_RUSTFLAGS on BOTH the package
+  # and its cargoArtifacts (deps-only cache). nix-lib's rust-builder.nix sets
+  # CARGO_BUILD_RUSTFLAGS as a derivation env var (linker flag / +crt-static),
+  # which *replaces* `.cargo/config.toml`'s `[build] rustflags` — so the tokio
+  # flags must be appended here to reach rustc for nix package builds. Reading
+  # `prev.CARGO_BUILD_RUSTFLAGS` preserves nix-lib's linker/static flags and works
+  # across local, cross-Linux, and Darwin builders. Applied as the innermost
+  # wrapper so deps and final stay consistent regardless of outer wrappers.
+  withTokioUnstable =
+    drv:
+    let
+      append = prev: "${prev.CARGO_BUILD_RUSTFLAGS or ""} ${tokioUnstableRustflags}";
+    in
+    drv.overrideAttrs (
+      prev:
+      {
+        CARGO_BUILD_RUSTFLAGS = append prev;
+      }
+      // {
+        cargoArtifacts =
+          if prev.cargoArtifacts != null then
+            prev.cargoArtifacts.overrideAttrs (depsPrev: {
+              CARGO_BUILD_RUSTFLAGS = append depsPrev;
+            })
+          else
+            null;
+      }
+    );
+
   # CC/CXX are arch-specific: cc-rs uses them to compile C code in build.rs scripts.
   withX86_64LinuxStaticEnv = mkWithStaticEnv (
     mkLinuxStaticEnv x86_64LinuxStaticPkgs
@@ -134,7 +170,12 @@ let
   withDarwinStaticFlags =
     drv:
     drv.overrideAttrs (prev: {
-      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv";
+      # Append any flags already on the final derivation (notably the
+      # tokio_unstable cfg stamped by withTokioUnstable) so replacing the base
+      # flags here does not drop them.
+      CARGO_BUILD_RUSTFLAGS =
+        "-C target-feature=+crt-static -C link-arg=-L/usr/lib -C link-arg=-liconv"
+        + lib.optionalString (prev ? CARGO_BUILD_RUSTFLAGS) " ${prev.CARGO_BUILD_RUSTFLAGS}";
 
       postInstall =
         lib.optionalString (prev ? postInstall && prev.postInstall != null) prev.postInstall
@@ -192,119 +233,139 @@ in
 
   # binary-gnosis_vpn (renamed from gnosis_vpn-release)
   binary-gnosis_vpn = withShellCompletions (
-    builders.local.callPackage nixLib.mkRustPackage (mkGnosisvpnBuildArgs {
-      src = sources.main;
-      depsSrc = sources.deps;
-    })
+    withTokioUnstable (
+      builders.local.callPackage nixLib.mkRustPackage (mkGnosisvpnBuildArgs {
+        src = sources.main;
+        depsSrc = sources.deps;
+      })
+    )
   );
 
   # binary-gnosis_vpn-dev (renamed from gnosis_vpn-dev)
   binary-gnosis_vpn-dev = withShellCompletions (
+    withTokioUnstable (
+      builders.local.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          CARGO_PROFILE = "dev";
+        }
+      )
+    )
+  );
+
+  # Cross-compiled — x86_64 Linux
+  binary-gnosis_vpn-x86_64-linux = withX86_64LinuxStaticEnv (
+    withTokioUnstable (
+      builders.x86_64-linux.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          extraBuildInputs = mkLinuxStaticBuildInputs x86_64LinuxStaticPkgs;
+        }
+      )
+    )
+  );
+
+  binary-gnosis_vpn-x86_64-linux-dev = withX86_64LinuxStaticEnv (
+    withTokioUnstable (
+      builders.x86_64-linux.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          CARGO_PROFILE = "dev";
+          extraBuildInputs = mkLinuxStaticBuildInputs x86_64LinuxStaticPkgs;
+        }
+      )
+    )
+  );
+
+  # Cross-compiled — aarch64 Linux
+  binary-gnosis_vpn-aarch64-linux = withAarch64LinuxStaticEnv (
+    withTokioUnstable (
+      builders.aarch64-linux.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          extraBuildInputs = mkLinuxStaticBuildInputs aarch64LinuxStaticPkgs;
+        }
+      )
+    )
+  );
+
+  binary-gnosis_vpn-aarch64-linux-dev = withAarch64LinuxStaticEnv (
+    withTokioUnstable (
+      builders.aarch64-linux.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          CARGO_PROFILE = "dev";
+          extraBuildInputs = mkLinuxStaticBuildInputs aarch64LinuxStaticPkgs;
+        }
+      )
+    )
+  );
+
+  # System test package: all service binaries + the system test runner in one derivation.
+  # Used by CI to run the system test against a live network in a single nix build command.
+  binary-gnosis_vpn-system_tests = withTokioUnstable (
+    builders.local.callPackage nixLib.mkRustPackage (
+      (mkGnosisvpnBuildArgs {
+        src = sources.main;
+        depsSrc = sources.deps;
+        extraCargoArgs = "--bin gnosis_vpn-system_tests";
+      })
+      // {
+        CARGO_PROFILE = "dev";
+      }
+    )
+  );
+
+  # Tests / QA
+  gnosis_vpn-test = withTokioUnstable (
+    builders.local.callPackage nixLib.mkRustPackage (
+      (mkGnosisvpnBuildArgs {
+        src = sources.test;
+        depsSrc = sources.deps;
+      })
+      // {
+        runTests = true;
+      }
+    )
+  );
+
+  gnosis_vpn-clippy = withTokioUnstable (
     builders.local.callPackage nixLib.mkRustPackage (
       (mkGnosisvpnBuildArgs {
         src = sources.main;
         depsSrc = sources.deps;
       })
       // {
-        CARGO_PROFILE = "dev";
+        runClippy = true;
       }
     )
   );
 
-  # Cross-compiled — x86_64 Linux
-  binary-gnosis_vpn-x86_64-linux = withX86_64LinuxStaticEnv (
-    builders.x86_64-linux.callPackage nixLib.mkRustPackage (
+  gnosis_vpn-docs = withTokioUnstable (
+    builders.localNightly.callPackage nixLib.mkRustPackage (
       (mkGnosisvpnBuildArgs {
         src = sources.main;
         depsSrc = sources.deps;
       })
       // {
-        extraBuildInputs = mkLinuxStaticBuildInputs x86_64LinuxStaticPkgs;
+        buildDocs = true;
       }
     )
-  );
-
-  binary-gnosis_vpn-x86_64-linux-dev = withX86_64LinuxStaticEnv (
-    builders.x86_64-linux.callPackage nixLib.mkRustPackage (
-      (mkGnosisvpnBuildArgs {
-        src = sources.main;
-        depsSrc = sources.deps;
-      })
-      // {
-        CARGO_PROFILE = "dev";
-        extraBuildInputs = mkLinuxStaticBuildInputs x86_64LinuxStaticPkgs;
-      }
-    )
-  );
-
-  # Cross-compiled — aarch64 Linux
-  binary-gnosis_vpn-aarch64-linux = withAarch64LinuxStaticEnv (
-    builders.aarch64-linux.callPackage nixLib.mkRustPackage (
-      (mkGnosisvpnBuildArgs {
-        src = sources.main;
-        depsSrc = sources.deps;
-      })
-      // {
-        extraBuildInputs = mkLinuxStaticBuildInputs aarch64LinuxStaticPkgs;
-      }
-    )
-  );
-
-  binary-gnosis_vpn-aarch64-linux-dev = withAarch64LinuxStaticEnv (
-    builders.aarch64-linux.callPackage nixLib.mkRustPackage (
-      (mkGnosisvpnBuildArgs {
-        src = sources.main;
-        depsSrc = sources.deps;
-      })
-      // {
-        CARGO_PROFILE = "dev";
-        extraBuildInputs = mkLinuxStaticBuildInputs aarch64LinuxStaticPkgs;
-      }
-    )
-  );
-
-  # System test package: all service binaries + the system test runner in one derivation.
-  # Used by CI to run the system test against a live network in a single nix build command.
-  binary-gnosis_vpn-system_tests = builders.local.callPackage nixLib.mkRustPackage (
-    (mkGnosisvpnBuildArgs {
-      src = sources.main;
-      depsSrc = sources.deps;
-      extraCargoArgs = "--bin gnosis_vpn-system_tests";
-    })
-    // {
-      CARGO_PROFILE = "dev";
-    }
-  );
-
-  # Tests / QA
-  gnosis_vpn-test = builders.local.callPackage nixLib.mkRustPackage (
-    (mkGnosisvpnBuildArgs {
-      src = sources.test;
-      depsSrc = sources.deps;
-    })
-    // {
-      runTests = true;
-    }
-  );
-
-  gnosis_vpn-clippy = builders.local.callPackage nixLib.mkRustPackage (
-    (mkGnosisvpnBuildArgs {
-      src = sources.main;
-      depsSrc = sources.deps;
-    })
-    // {
-      runClippy = true;
-    }
-  );
-
-  gnosis_vpn-docs = builders.localNightly.callPackage nixLib.mkRustPackage (
-    (mkGnosisvpnBuildArgs {
-      src = sources.main;
-      depsSrc = sources.deps;
-    })
-    // {
-      buildDocs = true;
-    }
   );
 
   # Audit dependencies
@@ -325,21 +386,25 @@ in
 // lib.optionalAttrs pkgs.stdenv.isDarwin {
   # macOS — aarch64 (only available on Darwin hosts; cctools is Darwin-only)
   binary-gnosis_vpn-aarch64-darwin = withDarwinStaticFlags (
-    builders.aarch64-darwin.callPackage nixLib.mkRustPackage (mkGnosisvpnBuildArgs {
-      src = sources.main;
-      depsSrc = sources.deps;
-    })
-  );
-
-  binary-gnosis_vpn-aarch64-darwin-dev = withDarwinStaticFlags (
-    builders.aarch64-darwin.callPackage nixLib.mkRustPackage (
-      (mkGnosisvpnBuildArgs {
+    withTokioUnstable (
+      builders.aarch64-darwin.callPackage nixLib.mkRustPackage (mkGnosisvpnBuildArgs {
         src = sources.main;
         depsSrc = sources.deps;
       })
-      // {
-        CARGO_PROFILE = "dev";
-      }
+    )
+  );
+
+  binary-gnosis_vpn-aarch64-darwin-dev = withDarwinStaticFlags (
+    withTokioUnstable (
+      builders.aarch64-darwin.callPackage nixLib.mkRustPackage (
+        (mkGnosisvpnBuildArgs {
+          src = sources.main;
+          depsSrc = sources.deps;
+        })
+        // {
+          CARGO_PROFILE = "dev";
+        }
+      )
     )
   );
 }

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -318,17 +318,13 @@ in
 
   # System test package: all service binaries + the system test runner in one derivation.
   # Used by CI to run the system test against a live network in a single nix build command.
+  # Builds with the default release profile so CI exercises the same binary users run.
   binary-gnosis_vpn-system_tests = withTokioUnstable (
-    builders.local.callPackage nixLib.mkRustPackage (
-      (mkGnosisvpnBuildArgs {
-        src = sources.main;
-        depsSrc = sources.deps;
-        extraCargoArgs = "--bin gnosis_vpn-system_tests";
-      })
-      // {
-        CARGO_PROFILE = "dev";
-      }
-    )
+    builders.local.callPackage nixLib.mkRustPackage (mkGnosisvpnBuildArgs {
+      src = sources.main;
+      depsSrc = sources.deps;
+      extraCargoArgs = "--bin gnosis_vpn-system_tests";
+    })
   );
 
   # Tests / QA


### PR DESCRIPTION
## Summary

Integrates the latest edge-client and runs the validated high-throughput HOPR session profile end-to-end:

- **Bumps `edgli`** to edge-client `main` `d5408a8b` ([#124](https://github.com/hoprnet/edge-client/pull/124), merged), which re-exports `FlowControlConfig` and tracks hoprnet `master` (`a511b8a8…`). Realigns `hopr-utils-session` to the same hoprnet rev (it still pinned an older commit, which pulled a second `hopr_lib` and caused type mismatches) and widens `bytesize`/`tokio` pins to satisfy the new graph.
- **Sets the robust flow-control profile** on the data-plane sessions — bridge (up/down) and WireGuard — via `HoprSessionClientConfig.flow_control = Some(FlowControlConfig::robust())`. This is the tail-tolerance profile validated for throttled / multi-hop paths. Route-health probe sessions deliberately stay on the default: robust's persistence would delay unhealthy-route detection.
- **Builds with `--cfg tokio_unstable`** for Tokio's improved cooperative yielding (part of the config that produced the validated throughput): `.cargo/config.toml` (`[build]` + the aarch64 target table), the dev-shell `shellHook`, and a `withTokioUnstable` wrapper that stamps `CARGO_BUILD_RUSTFLAGS` onto every nix package build's **deps and final** derivation so the flag survives nix-lib's linker rustflags across local / x86_64-linux / aarch64-linux / darwin.

Bumps the workspace to `0.94.0`.