### PR TITLE
feat(hopr): make channel transfer capacity configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -2788,8 +2788,8 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "3.5.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a#d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a"
+version = "4.0.0"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=a03d06b5f5e3f97c0880225313535826edd24c19#a03d06b5f5e3f97c0880225313535826edd24c19"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2814,6 +2814,7 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "smart-default",
+ "statrs",
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tokio",
@@ -3934,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.16.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8c7f28951b250cc61b68d8d06aa2d73fb05f96d19380325fc235924768f579"
+checksum = "aca8f552df157750ebad001edfa75851da1029461f3a60f60a41541dba39b3aa"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3946,7 +3947,6 @@ dependencies = [
  "futures-concurrency",
  "hopr-types",
  "libp2p-identity",
- "multiaddr",
  "serde",
  "strum 0.28.0",
  "thiserror 2.0.19",
@@ -3955,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.0"
+version = "4.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
+checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3974,7 +3974,8 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8326d358c768a169662397a7cd566a6fc4d4b8e394f285cd7cfcc7a6f6e866"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3987,7 +3988,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "moka",
  "parking_lot",
  "petgraph",
@@ -4004,13 +4005,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -4022,7 +4023,8 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c670d644ce0535d3fb6beb3b9ade0c67f0a24d6309b888f64f61dd0b9eb51eb3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4030,7 +4032,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "smart-default",
  "tracing",
  "validator",
@@ -4038,8 +4040,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.9"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+version = "4.0.2-rc.10"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4053,7 +4055,7 @@ dependencies = [
  "hopr-api",
  "hopr-network-graph",
  "hopr-transport",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -4070,13 +4072,14 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba5b6a91aeb80be5249798c975895d72d348c163317a3976359b5a10c89eb4b"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -4090,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4103,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4115,7 +4118,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4133,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4147,7 +4150,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4164,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4178,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b7849a82fe53e861a4938d1fab94123a16ba55917ff187de358610c07d599a"
+checksum = "ea1f49bc6a2bec90301732e3fbeee65eb3e67f82341b657e865adf51f0f6a024"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4190,7 +4193,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.4.1",
+ "hopr-utilities 0.5.1",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4208,7 +4211,8 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8009dca8550d8803bc730bb89e26a68316df041d4a131287e79b5e4fc9d4a413"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4217,7 +4221,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "parking_lot",
  "postcard",
  "redb",
@@ -4229,8 +4233,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.35.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+version = "0.37.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4252,7 +4256,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -4273,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4290,7 +4294,8 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e553e6688d8bf422a47cf382673752fbe3086f168e33dde006160481ec317a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4298,7 +4303,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4311,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4322,7 +4327,7 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
@@ -4336,8 +4341,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.24.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+version = "0.25.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4350,7 +4355,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4369,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4380,11 +4385,11 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.0.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
+checksum = "66c7725edf3080e937b9dcc66633003506c007da24706f6c3bcaf62443e2eb12"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "anyhow",
  "aquamarine",
  "arrayvec",
@@ -4440,22 +4445,24 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95680cead4b551cdeb76b016e99197f17b3528e790d1b37a7978b8e38e5f36b7"
+checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
 dependencies = [
  "auto_impl",
+ "const-hex",
  "futures",
  "indexmap 2.14.0",
+ "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-utilities"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
+checksum = "c557ecaad14224e4ae1df1be73449c24241f4b34e20129b11b8d0e38062eb6a6"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4488,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937"
+source = "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4500,7 +4507,7 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utilities 0.5.1",
+ "hopr-utilities 0.6.0",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",
@@ -4579,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "serde",
  "subtle",
@@ -7242,9 +7249,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7254,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9044,9 +9051,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=0060a2a0a7953228a1ae99a1ce5059136ff1edf9#0060a2a0a7953228a1ae99a1ce5059136ff1edf9"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=f87db85bec811efe4df96e3a626720d646871773#f87db85bec811efe4df96e3a626720d646871773"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -4180,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62774a0f288bc2e99ec1c4c9cc36eecec0cb5ef641c94b671a320372bb3d66f4"
+checksum = "777c6a3d4148f0bab96ce9ddc8d627d9e5c1249d63cf6618c2a896d9c3e1d032"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=9c6140ddd85da4f7be0a77e82c26435791112359#9c6140ddd85da4f7be0a77e82c26435791112359"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=0060a2a0a7953228a1ae99a1ce5059136ff1edf9#0060a2a0a7953228a1ae99a1ce5059136ff1edf9"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -4180,8 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.24.0"
-source = "git+https://github.com/hoprnet/hopr-strategy?rev=139b6b2#139b6b2c68e05265a7102adc430ff41116562840"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62774a0f288bc2e99ec1c4c9cc36eecec0cb5ef641c94b671a320372bb3d66f4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=68a215e1ead7457bd1aa34fd0e82c360bf355816#68a215e1ead7457bd1aa34fd0e82c360bf355816"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=c3634f6e81a2adc47716eff41a0eab33a73b5464#c3634f6e81a2adc47716eff41a0eab33a73b5464"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2814,7 +2814,6 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "smart-default",
- "statrs",
  "strum 0.28.0",
  "thiserror 2.0.19",
  "tokio",
@@ -4181,9 +4180,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1f49bc6a2bec90301732e3fbeee65eb3e67f82341b657e865adf51f0f6a024"
+version = "0.24.0"
+source = "git+https://github.com/hoprnet/hopr-strategy?rev=139b6b2#139b6b2c68e05265a7102adc430ff41116562840"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=a03d06b5f5e3f97c0880225313535826edd24c19#a03d06b5f5e3f97c0880225313535826edd24c19"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049#2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=c3634f6e81a2adc47716eff41a0eab33a73b5464#c3634f6e81a2adc47716eff41a0eab33a73b5464"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=9c6140ddd85da4f7be0a77e82c26435791112359#9c6140ddd85da4f7be0a77e82c26435791112359"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.0.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049#2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=68a215e1ead7457bd1aa34fd0e82c360bf355816#68a215e1ead7457bd1aa34fd0e82c360bf355816"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "a03d06b5f5e3f97c0880225313535826edd24c19", features = [
   "blokli",
   "telemetry",
 ] }
 exitcode = "~1.1.2"
 futures = "~0.3.33"
 futures-util = "~0.3.33"
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a511b8a88b297f47a15986573bf6db3ef7b95937", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "~0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "68a215e1ead7457bd1aa34fd0e82c360bf355816", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "a03d06b5f5e3f97c0880225313535826edd24c19", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "9c6140ddd85da4f7be0a77e82c26435791112359", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "0060a2a0a7953228a1ae99a1ce5059136ff1edf9", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "0060a2a0a7953228a1ae99a1ce5059136ff1edf9", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "f87db85bec811efe4df96e3a626720d646871773", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "68a215e1ead7457bd1aa34fd0e82c360bf355816", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "c3634f6e81a2adc47716eff41a0eab33a73b5464", features = [
   "blokli",
   "telemetry",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.4", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "c3634f6e81a2adc47716eff41a0eab33a73b5464", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "9c6140ddd85da4f7be0a77e82c26435791112359", features = [
   "blokli",
   "telemetry",
 ] }

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -154,10 +154,6 @@ path    = { hops = 1 }
 # min_open_channels = 5
 # target number of open outgoing channels
 # target_open_channels = 8
-# data volume a single payment channel should be able to carry before it needs a top-up.
-# Larger values fund channels further ahead, but require a correspondingly larger safe
-# balance before any channel is opened. Left unset, a sensible default is used.
-# channel_capacity = "1 GiB"
 # channel allowlist: when enabled, restricts channel opening to the listed peers only.
 # When disabled (default), peers are selected by quality score.
 # [strategy.channel_allowlist]

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -155,10 +155,8 @@ path    = { hops = 1 }
 # target number of open outgoing channels
 # target_open_channels = 8
 # data volume a single payment channel should be able to carry before it needs a top-up.
-# The stake required to cover it is derived from the live ticket price and winning
-# probability; a top-up is triggered once a quarter of it is left, and the safe must hold
-# a quarter more than this before a channel is opened. Values below the one-winning-ticket
-# floor have no effect, since a channel that cannot cover a single ticket cannot relay.
+# Larger values fund channels further ahead, but require a correspondingly larger safe
+# balance before any channel is opened. Left unset, a sensible default is used.
 # channel_capacity = "1 GiB"
 # channel allowlist: when enabled, restricts channel opening to the listed peers only.
 # When disabled (default), peers are selected by quality score.

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -154,6 +154,12 @@ path    = { hops = 1 }
 # min_open_channels = 5
 # target number of open outgoing channels
 # target_open_channels = 8
+# data volume a single payment channel should be able to carry before it needs a top-up.
+# The stake required to cover it is derived from the live ticket price and winning
+# probability; a top-up is triggered once a quarter of it is left, and the safe must hold
+# a quarter more than this before a channel is opened. Values below the one-winning-ticket
+# floor have no effect, since a channel that cannot cover a single ticket cannot relay.
+# channel_capacity = "1 GiB"
 # channel allowlist: when enabled, restricts channel opening to the listed peers only.
 # When disabled (default), peers are selected by quality score.
 # [strategy.channel_allowlist]

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -513,7 +513,7 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
         if key == "strategy" {
             if let Some(strategy) = value.as_table() {
                 for (k, v) in strategy.iter() {
-                    if k == "min_open_channels" || k == "target_open_channels" {
+                    if k == "min_open_channels" || k == "target_open_channels" || k == "channel_capacity" {
                         continue;
                     }
                     if k == "channel_allowlist" {
@@ -550,6 +550,7 @@ pub(super) struct Strategy {
     pub(super) min_open_channels: Option<usize>,
     pub(super) target_open_channels: Option<usize>,
     pub(super) channel_allowlist: Option<ChannelAllowlistConfig>,
+    pub(super) channel_capacity: Option<ByteSize>,
 }
 
 impl From<Option<Strategy>> for StrategyConfig {
@@ -568,6 +569,7 @@ impl From<Option<Strategy>> for StrategyConfig {
                 .as_ref()
                 .and_then(|s| s.channel_allowlist.as_ref())
                 .and_then(|c| c.enabled.then(|| c.peers.iter().cloned().collect())),
+            channel_capacity: v.as_ref().and_then(|s| s.channel_capacity).or(def.channel_capacity),
         }
     }
 }
@@ -936,6 +938,57 @@ path_planner_min_ack_rate = {bad}
     }
 
     #[test]
+    fn strategy_channel_capacity_is_parsed() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[strategy]
+channel_capacity = "1 GiB"
+"#####,
+        );
+        let strategy = cfg.strategy.expect("strategy section present");
+        assert_eq!(strategy.channel_capacity, Some(bytesize::ByteSize::gib(1)));
+
+        let converted: StrategyConfig = Some(strategy).into();
+        assert_eq!(converted.channel_capacity, Some(bytesize::ByteSize::gib(1)));
+    }
+
+    #[test]
+    fn strategy_channel_capacity_is_optional() {
+        let cfg = parse(
+            r#####"
+version = 6
+
+[strategy]
+target_open_channels = 8
+"#####,
+        );
+        let strategy = cfg.strategy.expect("strategy section present");
+        assert!(strategy.channel_capacity.is_none());
+
+        // Left unset so edgli applies its own sizing rather than a local value.
+        let converted: StrategyConfig = Some(strategy).into();
+        assert!(converted.channel_capacity.is_none());
+    }
+
+    #[test]
+    fn strategy_channel_capacity_is_a_known_key() {
+        // An unlisted key still loads, but `wrong_keys` makes the daemon log it as
+        // unsupported — a misleading warning for a key that is honoured.
+        let table = r#####"
+version = 6
+
+[strategy]
+channel_capacity = "1 GiB"
+"#####
+            .parse::<toml::Table>()
+            .expect("valid TOML");
+
+        assert_eq!(wrong_keys(&table), Vec::<String>::new());
+    }
+
+    #[test]
     fn strategy_channel_allowlist_enabled_produces_some() {
         let addr: Address = "0xD9c11f07BfBC1914877d7395459223aFF9Dc2739".parse().unwrap();
         let strategy = Some(Strategy {
@@ -945,6 +998,7 @@ path_planner_min_ack_rate = {bad}
                 enabled: true,
                 peers: vec![addr],
             }),
+            channel_capacity: None,
         });
         let cfg: StrategyConfig = strategy.into();
         assert_eq!(cfg.channel_allowlist, Some(std::collections::HashSet::from([addr])));
@@ -960,6 +1014,7 @@ path_planner_min_ack_rate = {bad}
                 enabled: false,
                 peers: vec![addr],
             }),
+            channel_capacity: None,
         });
         let cfg: StrategyConfig = strategy.into();
         assert!(cfg.channel_allowlist.is_none());

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -513,7 +513,10 @@ pub fn wrong_keys(table: &toml::Table) -> Vec<String> {
         if key == "strategy" {
             if let Some(strategy) = value.as_table() {
                 for (k, v) in strategy.iter() {
-                    if k == "min_open_channels" || k == "target_open_channels" || k == "channel_capacity" {
+                    if matches!(
+                        k.as_str(),
+                        "min_open_channels" | "target_open_channels" | "channel_capacity"
+                    ) {
                         continue;
                     }
                     if k == "channel_allowlist" {

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -553,7 +553,30 @@ pub(super) struct Strategy {
     pub(super) min_open_channels: Option<usize>,
     pub(super) target_open_channels: Option<usize>,
     pub(super) channel_allowlist: Option<ChannelAllowlistConfig>,
+    #[serde(default, deserialize_with = "validate_channel_capacity")]
     pub(super) channel_capacity: Option<ByteSize>,
+}
+
+/// Rejects a capacity edgli cannot turn into a funding config.
+///
+/// It derives the safe balance gate by scaling the capacity up, so a value near
+/// `u64::MAX` overflows and fails every reactor start. That failure is retried on a
+/// timer with a generic message, so without this the config loads fine and the node
+/// silently never opens a channel — naming the key here turns it into a load error.
+fn validate_channel_capacity<'de, D>(deserializer: D) -> Result<Option<ByteSize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    /// Headroom edgli needs above the requested capacity to size the safe gate.
+    const MAX_SAFE_SCALING: u64 = 2;
+
+    match Option::<ByteSize>::deserialize(deserializer)? {
+        Some(v) if v.as_u64() > u64::MAX / MAX_SAFE_SCALING => Err(serde::de::Error::custom(format!(
+            "channel_capacity must not exceed {}",
+            ByteSize::b(u64::MAX / MAX_SAFE_SCALING)
+        ))),
+        other => Ok(other),
+    }
 }
 
 impl From<Option<Strategy>> for StrategyConfig {
@@ -572,7 +595,7 @@ impl From<Option<Strategy>> for StrategyConfig {
                 .as_ref()
                 .and_then(|s| s.channel_allowlist.as_ref())
                 .and_then(|c| c.enabled.then(|| c.peers.iter().cloned().collect())),
-            channel_capacity: v.as_ref().and_then(|s| s.channel_capacity).or(def.channel_capacity),
+            channel_capacity: v.as_ref().and_then(|s| s.channel_capacity),
         }
     }
 }
@@ -955,6 +978,25 @@ channel_capacity = "1 GiB"
 
         let converted: StrategyConfig = Some(strategy).into();
         assert_eq!(converted.channel_capacity, Some(bytesize::ByteSize::gib(1)));
+    }
+
+    #[test]
+    fn strategy_channel_capacity_rejects_a_value_that_overflows_the_safe_gate() {
+        // Without the bound this loads fine and then fails every reactor start on a
+        // 10s retry, with nothing naming the offending key.
+        let err = toml::from_str::<Config>(
+            r#####"
+version = 6
+
+[strategy]
+channel_capacity = "16 EiB"
+"#####,
+        )
+        .expect_err("16 EiB must be rejected");
+        assert!(
+            err.to_string().contains("channel_capacity"),
+            "error should name the key, got: {err}"
+        );
     }
 
     #[test]

--- a/gnosis_vpn-lib/src/hopr/api.rs
+++ b/gnosis_vpn-lib/src/hopr/api.rs
@@ -345,8 +345,7 @@ impl Hopr {
         &self,
         sizing: edgli::strategy::IncentiveConfiguration,
     ) -> Result<AbortHandle, HoprError> {
-        let mut cfg = edgli::strategy::default_strategy_cfg(&self.edgli, &sizing)
-            .await
+        let mut cfg = edgli::strategy::default_strategy_cfg(&sizing)
             .map_err(|e| HoprError::TelemetryReactorStart(e.to_string()))?;
         match cfg.strategies.first_mut() {
             Some(edgli::strategy::EdgeStrategyKind::ChannelLifecycle(lc)) => {

--- a/gnosis_vpn-lib/src/hopr/strategy_config.rs
+++ b/gnosis_vpn-lib/src/hopr/strategy_config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use bytesize::ByteSize;
 use edgli::hopr_lib::api::types::primitive::prelude::Address;
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +19,13 @@ pub struct StrategyConfig {
 
     /// When `Some`, channels are opened exclusively to these peers; `None` uses quality-score selection.
     pub channel_allowlist: Option<HashSet<Address>>,
+
+    /// Data volume a single channel should be able to carry before it needs a top-up.
+    ///
+    /// The only sizing input we supply; edgli derives the funding capacities, the sizing
+    /// mode, and the resulting stakes from it. `None` leaves edgli's default sizing in
+    /// place. Values below the one-winning-ticket floor have no effect.
+    pub channel_capacity: Option<ByteSize>,
 }
 
 impl Default for StrategyConfig {
@@ -27,6 +35,7 @@ impl Default for StrategyConfig {
             min_open_channels: def.min_open_channels,
             target_open_channels: def.target_open_channels,
             channel_allowlist: def.channel_allowlist,
+            channel_capacity: def.channel_capacity,
         }
     }
 }
@@ -37,6 +46,7 @@ impl From<StrategyConfig> for edgli::strategy::IncentiveConfiguration {
             min_open_channels: c.min_open_channels,
             target_open_channels: c.target_open_channels,
             channel_allowlist: c.channel_allowlist,
+            channel_capacity: c.channel_capacity,
         }
     }
 }

--- a/gnosis_vpn-lib/src/hopr/strategy_config.rs
+++ b/gnosis_vpn-lib/src/hopr/strategy_config.rs
@@ -20,11 +20,11 @@ pub struct StrategyConfig {
     /// When `Some`, channels are opened exclusively to these peers; `None` uses quality-score selection.
     pub channel_allowlist: Option<HashSet<Address>>,
 
-    /// Data volume a single channel should be able to carry before it needs a top-up.
+    /// Data volume a single channel should carry before it needs a top-up.
     ///
-    /// The only sizing input we supply; edgli derives the funding capacities, the sizing
-    /// mode, and the resulting stakes from it. `None` leaves edgli's default sizing in
-    /// place. Values below the one-winning-ticket floor have no effect.
+    /// The only sizing input we supply; edgli derives the capacities, sizing mode and
+    /// stakes from it. `None` leaves edgli's default in place, and values below the
+    /// one-winning-ticket floor have no effect.
     pub channel_capacity: Option<ByteSize>,
 }
 

--- a/gnosis_vpn-lib/src/hopr/strategy_config.rs
+++ b/gnosis_vpn-lib/src/hopr/strategy_config.rs
@@ -22,9 +22,9 @@ pub struct StrategyConfig {
 
     /// Data volume a single channel should carry before it needs a top-up.
     ///
-    /// The only sizing input we supply; edgli derives the capacities, sizing mode and
-    /// stakes from it. `None` leaves edgli's default in place, and values below the
-    /// one-winning-ticket floor have no effect.
+    /// The only sizing input we supply; edgli derives the sizing mode and stakes from it
+    /// and passes it to the strategy as given. `None` leaves edgli's default in place.
+    /// Raising it also raises the safe balance required before any channel opens.
     pub channel_capacity: Option<ByteSize>,
 }
 

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049#2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049" =
-      "sha256-P9KIAEpH09YBWzhL93FQgtRcE04LhmDR/vMCc0gr1OM=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=68a215e1ead7457bd1aa34fd0e82c360bf355816#68a215e1ead7457bd1aa34fd0e82c360bf355816" =
+      "sha256-MND56D31lRI8o7T7CrHPa62QadM8seQxK41xilzbf8g=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,10 +33,10 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a#d5408a8b3da3d56e3fd7bf3a89f3f915b1804d1a" =
-      "sha256-j2qKPal/t24W0B7okAZ2ntTXCp3Ai4Bh8ZCIun0WBG4=";
-    "git+https://github.com/hoprnet/hoprnet?rev=a511b8a88b297f47a15986573bf6db3ef7b95937#a511b8a88b297f47a15986573bf6db3ef7b95937" =
-      "sha256-ir25ZsBHxw93aQIOISiUYrX6BOl4t4jdHHKr9dz78Uo=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=a03d06b5f5e3f97c0880225313535826edd24c19#a03d06b5f5e3f97c0880225313535826edd24c19" =
+      "sha256-ybbGs7ZlfM1TggcbCVszC7eYhSiVVhKZxmCw25ggHnw=";
+    "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
+      "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };
 
   builders = nixLib.mkRustBuilders {

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=a03d06b5f5e3f97c0880225313535826edd24c19#a03d06b5f5e3f97c0880225313535826edd24c19" =
-      "sha256-ybbGs7ZlfM1TggcbCVszC7eYhSiVVhKZxmCw25ggHnw=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049#2eccc0ce6fcbf3b37de064c514f0ff1eb37e8049" =
+      "sha256-P9KIAEpH09YBWzhL93FQgtRcE04LhmDR/vMCc0gr1OM=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=9c6140ddd85da4f7be0a77e82c26435791112359#9c6140ddd85da4f7be0a77e82c26435791112359" =
-      "sha256-Q4SE6oN/AhDIz16PWTN6wonl9kZVTHyz+d5ZPyFNTyk=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=0060a2a0a7953228a1ae99a1ce5059136ff1edf9#0060a2a0a7953228a1ae99a1ce5059136ff1edf9" =
+      "sha256-aNa+JQPkMja9TS5xrm77niNQs/UnEZAai1XsiES30xs=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=68a215e1ead7457bd1aa34fd0e82c360bf355816#68a215e1ead7457bd1aa34fd0e82c360bf355816" =
-      "sha256-MND56D31lRI8o7T7CrHPa62QadM8seQxK41xilzbf8g=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=c3634f6e81a2adc47716eff41a0eab33a73b5464#c3634f6e81a2adc47716eff41a0eab33a73b5464" =
+      "sha256-tq1N1yikuILZsdgTQwzckV+vfpNLYuK9TUNQONMpmsM=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=0060a2a0a7953228a1ae99a1ce5059136ff1edf9#0060a2a0a7953228a1ae99a1ce5059136ff1edf9" =
-      "sha256-aNa+JQPkMja9TS5xrm77niNQs/UnEZAai1XsiES30xs=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=f87db85bec811efe4df96e3a626720d646871773#f87db85bec811efe4df96e3a626720d646871773" =
+      "sha256-uOEGGMG0N7t6O4oUQbMcU3nPyb+XbO4Xth/uc6CmEv4=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,8 +33,8 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=c3634f6e81a2adc47716eff41a0eab33a73b5464#c3634f6e81a2adc47716eff41a0eab33a73b5464" =
-      "sha256-tq1N1yikuILZsdgTQwzckV+vfpNLYuK9TUNQONMpmsM=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=9c6140ddd85da4f7be0a77e82c26435791112359#9c6140ddd85da4f7be0a77e82c26435791112359" =
+      "sha256-Q4SE6oN/AhDIz16PWTN6wonl9kZVTHyz+d5ZPyFNTyk=";
     "git+https://github.com/hoprnet/hoprnet?rev=10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d#10f6d80c3cc71dee1c5f98c3074c4021ef7fa54d" =
       "sha256-k0vvNTgGadrK1RyXwvABBpDWymsMEBXa+4wg9WLjtro=";
   };


### PR DESCRIPTION
Bumps `edgli` to the revision that owns channel sizing end to end, and exposes the one input it now takes from us.

Depends on: https://github.com/hoprnet/edge-client/pull/136

## Why

edgli derived the reactor's funding config and its balance recommendations through two independent paths, so a caller that tuned the sizing mode desynced them.

We were such a caller. We overrode `sizing_mode` on the channel-lifecycle config to get a margin above the ~1-ticket-price lower threshold, where lumpy ticket payouts otherwise starve a channel mid-relay. The recommendation kept mirroring the untuned mode, so it under-reported what the strategy locks — and since the strategy's own `min_safe_capacity_required` gate resolves through the same mode, a node funded to our recommendation would have quietly refused to open channels.

Sizing now lives entirely in edgli, driven by a single requested transfer volume, with the recommendation derived from the same config the reactor runs on. The local `sizing_mode` override is gone; edgli picks `Probabilistic(0.99)` itself.

## What

**`strategy.channel_capacity`** — the data volume a single channel should be able to carry before it needs a top-up. It reaches the strategy unchanged as the initial capacity; top-up and lower threshold keep the strategy's own defaults. Left unset, edgli's default sizing applies unchanged.

Raising it also raises the Safe balance required before *any* channel opens — the gate is `max(2 × channel_capacity, strategy default)`. A value that cannot be sized without overflowing is rejected at config load with an error naming the key, rather than failing repeatedly inside the retry loop.

The key is deliberately **not listed in `documented-config.toml`**: it stays a direct way to manipulate sizing without advertising it to operators. It is still deserialized, range-validated and allowlisted — just undocumented.

**`hopr-utils-session`** moves to the hoprnet revision edgli now builds against; the previous pin requires `hopr-api ^1.16` while the new dependencies require `^1.19`.

## Upgrade impact — existing nodes need more wxHOPR

This raises what a node must hold before it will open or top up a channel, for **every** node, including ones that never set `channel_capacity`:

- `Probabilistic(0.99)` replaces `Deterministic`, adding `k·σ` (`k ≈ 2.33`) on top of the mean drain.
- the safe gate is `max(2 × initial capacity, strategy default)`, where it previously equalled the initial capacity.

`stop_when_unfunded` is always set, and the strategy gates every open and every top-up on the safe balance clearing that figure. So a node whose Safe was funded to exactly the pre-upgrade recommendation will, after upgrading, open no channels and perform no top-ups — existing channels drain and connectivity degrades — until more wxHOPR is added.

`minimum_balance_recommendation` reports the new figure, and it now comes from the strategy's own resolution, so it is the number to fund to. **This wants a release note.**

## Funding rises three ways at once

`hopr-strategy` 0.25.0 lands three compounding increases, and the client picks up all of them here:

- `Probabilistic(0.99)` instead of `Deterministic` — adds `k·σ` (`k ≈ 2.33`) above the mean drain.
- stakes sized for **3 hops instead of 1** — the protocol maximum, since the issuing node cannot know a packet's path length. Triples the face value each ticket locks.
- each stake rounded up to a whole winning ticket, since a channel pays out only in whole tickets.

Plus this PR's own change: the safe gate is `max(2 × channel_capacity, strategy default)`.

`minimum_balance_recommendation` reports the resulting figure and comes from the strategy's own resolution, so it stays the number to fund to. A node funded to the pre-upgrade recommendation will open no channels and perform no top-ups until more wxHOPR is added. **This wants a release note.**

## Follow-up

`hopr-strategy` is released as 0.25.0 and edgli takes it from crates.io, so the transitive git source and its `outputHashes` entry are both gone. The Rust 1.97 bump this needed landed independently on main in #716.

One pin remains: `edgli` tracks the branch of #136 and needs re-pointing to its merge commit, with a refreshed `nix/gnosisvpn.nix` output hash.
