### PR TITLE
feat(wg): expose tunnel stats (throughput, rtt, handshake age, loss) …

### DIFF
--- a/gnosis_vpn-ctl/src/main.rs
+++ b/gnosis_vpn-ctl/src/main.rs
@@ -529,6 +529,7 @@ fn print_connecting_stats(stats: &command::ConnStats) {
         )
         .as_str(),
     );
+    str_resp.push_str(&print_wg_tunnel_stats(stats));
     println!("{str_resp}");
 }
 
@@ -548,7 +549,29 @@ fn print_connected_stats(stats: &command::ConnStats) {
     if let Some(ref wg_pubkey) = stats.wg_server_pubkey {
         str_resp.push_str(format!("---\nExit WireGuard Public Key: {}\n", wg_pubkey).as_str());
     }
+    str_resp.push_str(&print_wg_tunnel_stats(stats));
     println!("{str_resp}");
+}
+
+/// Render the last WireGuard tunnel stats sample, if the pump has started and
+/// recorded one. `rtt`/handshake age are labeled "as of last handshake", not
+/// "current" - WireGuard only updates them on a handshake, which recurs every
+/// ~120s on an active tunnel, so they can be meaningfully stale.
+fn print_wg_tunnel_stats(stats: &command::ConnStats) -> String {
+    let Some(current) = stats.wg_stats.as_ref().and_then(|s| s.current.as_ref()) else {
+        return String::new();
+    };
+    let rtt = current.rtt_ms.map(|ms| format!("{ms}ms")).unwrap_or("--".to_string());
+    let handshake_age = current
+        .time_since_last_handshake
+        .map(|d| format!("{:.0}s ago", d.as_secs_f64()))
+        .unwrap_or("--".to_string());
+    format!(
+        "---\nTunnel RTT (as of last handshake): {rtt}\nLast handshake: {handshake_age}\nTx bytes: {}\nRx bytes: {}\nEstimated loss: {:.1}%\n",
+        current.tx_bytes,
+        current.rx_bytes,
+        current.estimated_loss * 100.0,
+    )
 }
 
 fn print_session(session: &command::ActiveSession) -> String {

--- a/gnosis_vpn-lib/src/command/mod.rs
+++ b/gnosis_vpn-lib/src/command/mod.rs
@@ -327,7 +327,10 @@ impl ConnStats {
             wg_ip: conn.registration.as_ref().map(|reg| reg.address().to_string()),
             bridge_session,
             main_session,
-            wg_stats: conn.wg_stats.as_ref().map(|handle| handle.snapshot()),
+            wg_stats: (!conn.wg_stats.is_empty()).then(|| crate::wg_tunnel::WgTunnelStats {
+                current: conn.wg_stats.back().cloned(),
+                history: conn.wg_stats.iter().cloned().collect(),
+            }),
         }
     }
 }

--- a/gnosis_vpn-lib/src/command/mod.rs
+++ b/gnosis_vpn-lib/src/command/mod.rs
@@ -297,6 +297,10 @@ pub struct ConnStats {
     pub wg_ip: Option<String>,
     pub bridge_session: Option<ActiveSession>,
     pub main_session: Option<ActiveSession>,
+    /// WireGuard tunnel counters/timers as of the last stats sample, if the
+    /// pump has started. See [`crate::wg_tunnel::TunnelStatsSample`] for why
+    /// `rtt_ms`/`time_since_last_handshake` reflect the last handshake, not "now".
+    pub wg_stats: Option<crate::wg_tunnel::WgTunnelStats>,
 }
 
 impl ConnStats {
@@ -323,6 +327,7 @@ impl ConnStats {
             wg_ip: conn.registration.as_ref().map(|reg| reg.address().to_string()),
             bridge_session,
             main_session,
+            wg_stats: conn.wg_stats.as_ref().map(|handle| handle.snapshot()),
         }
     }
 }
@@ -846,5 +851,60 @@ mod tests {
 
         let with_error: RunMode = serde_json::from_str(r#"{"Init":{"last_error":"connection refused"}}"#).unwrap();
         assert!(matches!(with_error, RunMode::Init { last_error: Some(ref e) } if e == "connection refused"));
+    }
+
+    #[test]
+    fn wg_tunnel_stats_serializes_to_expected_json_shape() {
+        use crate::wg_tunnel::{TunnelStatsSample, WgTunnelStats};
+
+        let empty = serde_json::to_string(&WgTunnelStats::default()).unwrap();
+        assert_eq!(empty, r#"{"current":null,"history":[]}"#);
+
+        // SystemTime::UNIX_EPOCH keeps the fixture deterministic (no wall-clock read).
+        let sample = TunnelStatsSample {
+            at: SystemTime::UNIX_EPOCH,
+            tx_bytes: 100,
+            rx_bytes: 200,
+            rtt_ms: Some(42),
+            time_since_last_handshake: Some(Duration::from_secs(5)),
+            estimated_loss: 0.1,
+        };
+        let populated = serde_json::to_string(&WgTunnelStats {
+            current: Some(sample.clone()),
+            history: vec![sample],
+        })
+        .unwrap();
+        let sample_json = concat!(
+            r#"{"at":{"secs_since_epoch":0,"nanos_since_epoch":0},"#,
+            r#""tx_bytes":100,"rx_bytes":200,"rtt_ms":42,"#,
+            r#""time_since_last_handshake":{"secs":5,"nanos":0},"estimated_loss":0.1}"#
+        );
+        assert_eq!(
+            populated,
+            format!(r#"{{"current":{sample_json},"history":[{sample_json}]}}"#)
+        );
+    }
+
+    #[test]
+    fn wg_tunnel_stats_deserializes_from_json_fixture() {
+        use crate::wg_tunnel::WgTunnelStats;
+
+        let empty: WgTunnelStats = serde_json::from_str(r#"{"current":null,"history":[]}"#).unwrap();
+        assert!(empty.current.is_none());
+        assert!(empty.history.is_empty());
+
+        let sample_json = concat!(
+            r#"{"at":{"secs_since_epoch":0,"nanos_since_epoch":0},"#,
+            r#""tx_bytes":100,"rx_bytes":200,"rtt_ms":42,"#,
+            r#""time_since_last_handshake":{"secs":5,"nanos":0},"estimated_loss":0.1}"#
+        );
+        let populated: WgTunnelStats =
+            serde_json::from_str(&format!(r#"{{"current":{sample_json},"history":[{sample_json}]}}"#)).unwrap();
+        let current = populated.current.expect("current sample present");
+        assert_eq!(current.tx_bytes, 100);
+        assert_eq!(current.rx_bytes, 200);
+        assert_eq!(current.rtt_ms, Some(42));
+        assert_eq!(current.time_since_last_handshake, Some(Duration::from_secs(5)));
+        assert_eq!(populated.history.len(), 1);
     }
 }

--- a/gnosis_vpn-lib/src/connection/up/mod.rs
+++ b/gnosis_vpn-lib/src/connection/up/mod.rs
@@ -1,9 +1,10 @@
+use edgli::hopr_lib::exports::transport::HoprSessionConfigurator;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use std::collections::VecDeque;
 use std::fmt::{self, Display};
 use std::net;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use crate::connection::destination::Destination;
@@ -11,7 +12,7 @@ use crate::connection::options::SurbConfigError;
 use crate::gvpn_client::Registration;
 use crate::hopr::HoprError;
 use crate::hopr::types::SessionClientMetadata;
-use crate::wg_tunnel::WgTunnelStatsHandle;
+use crate::wg_tunnel::{self, TunnelStatsSample};
 use crate::wireguard::WireGuard;
 use crate::{gvpn_client, log_output, remote_data, wireguard};
 
@@ -41,7 +42,9 @@ pub enum Progress {
     PeerIps,
     KillswitchLockdown,
     StaticWgTunnel(SessionClientMetadata),
-    WgPumpStarted(Arc<WgTunnelStatsHandle>),
+    /// Handle to adjust the active session's SURB balancer, retained on `Up`
+    /// so `core` can reconfigure it from live telemetry, not just once here.
+    SessionConfigurator(HoprSessionConfigurator),
     Ping,
     AdjustToMain(Duration),
 }
@@ -88,8 +91,13 @@ pub struct Up {
     pub bridge_session: Option<SessionClientMetadata>,
     /// The ping session while connecting, promoted to Main once connected.
     pub ping_session: Option<(SessionKind, SessionClientMetadata)>,
-    /// Handle to the running pump's tunnel stats, set once the pump starts.
-    pub wg_stats: Option<Arc<WgTunnelStatsHandle>>,
+    /// Bounded rolling window of tunnel telemetry, oldest first. Owned directly
+    /// by `core` (a single-threaded actor), so no lock is needed. Reset per
+    /// connection attempt since `Up` itself is freshly constructed per attempt.
+    pub wg_stats: VecDeque<TunnelStatsSample>,
+    /// Handle to adjust the active session's SURB balancer from telemetry.
+    /// Retained past the initial ping->main adjustment so it can be reused.
+    pub session_configurator: Option<HoprSessionConfigurator>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -123,8 +131,18 @@ impl Up {
             registration: None,
             bridge_session: None,
             ping_session: None,
-            wg_stats: None,
+            wg_stats: VecDeque::new(),
+            session_configurator: None,
         }
+    }
+
+    /// Record a new WireGuard telemetry sample, evicting the oldest once at
+    /// the retention bound.
+    pub fn record_wg_stats(&mut self, sample: TunnelStatsSample) {
+        if self.wg_stats.len() >= wg_tunnel::HISTORY_CAPACITY {
+            self.wg_stats.pop_front();
+        }
+        self.wg_stats.push_back(sample);
     }
 
     pub fn connect_progress(&mut self, evt: Box<Progress>) {
@@ -153,8 +171,8 @@ impl Up {
                 self.phase = (now, Phase::EstablishWgTunnel);
                 self.ping_session = Some((SessionKind::Ping, session));
             }
-            Progress::WgPumpStarted(handle) => {
-                self.wg_stats = Some(handle);
+            Progress::SessionConfigurator(configurator) => {
+                self.session_configurator = Some(configurator);
             }
             Progress::Ping => self.phase = (now, Phase::VerifyPing),
             Progress::AdjustToMain(_round_trip_time) => self.phase = (now, Phase::AdjustToMain),
@@ -223,7 +241,7 @@ impl Display for Progress {
             Progress::PeerIps => write!(f, "Retrieving peer IPs"),
             Progress::KillswitchLockdown => write!(f, "Activating killswitch"),
             Progress::StaticWgTunnel(_) => write!(f, "Establishing static WireGuard tunnel"),
-            Progress::WgPumpStarted(_) => write!(f, "WireGuard pump started"),
+            Progress::SessionConfigurator(_) => write!(f, "Session configurator retained"),
             Progress::Ping => write!(f, "Verifying established connection"),
             Progress::AdjustToMain(round_trip_time) => {
                 write!(f, "Adjusting to main connection with RTT of {:?}", round_trip_time)

--- a/gnosis_vpn-lib/src/connection/up/mod.rs
+++ b/gnosis_vpn-lib/src/connection/up/mod.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 use std::fmt::{self, Display};
 use std::net;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use crate::connection::destination::Destination;
@@ -10,6 +11,7 @@ use crate::connection::options::SurbConfigError;
 use crate::gvpn_client::Registration;
 use crate::hopr::HoprError;
 use crate::hopr::types::SessionClientMetadata;
+use crate::wg_tunnel::WgTunnelStatsHandle;
 use crate::wireguard::WireGuard;
 use crate::{gvpn_client, log_output, remote_data, wireguard};
 
@@ -39,6 +41,7 @@ pub enum Progress {
     PeerIps,
     KillswitchLockdown,
     StaticWgTunnel(SessionClientMetadata),
+    WgPumpStarted(Arc<WgTunnelStatsHandle>),
     Ping,
     AdjustToMain(Duration),
 }
@@ -85,6 +88,8 @@ pub struct Up {
     pub bridge_session: Option<SessionClientMetadata>,
     /// The ping session while connecting, promoted to Main once connected.
     pub ping_session: Option<(SessionKind, SessionClientMetadata)>,
+    /// Handle to the running pump's tunnel stats, set once the pump starts.
+    pub wg_stats: Option<Arc<WgTunnelStatsHandle>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -118,6 +123,7 @@ impl Up {
             registration: None,
             bridge_session: None,
             ping_session: None,
+            wg_stats: None,
         }
     }
 
@@ -146,6 +152,9 @@ impl Up {
             Progress::StaticWgTunnel(session) => {
                 self.phase = (now, Phase::EstablishWgTunnel);
                 self.ping_session = Some((SessionKind::Ping, session));
+            }
+            Progress::WgPumpStarted(handle) => {
+                self.wg_stats = Some(handle);
             }
             Progress::Ping => self.phase = (now, Phase::VerifyPing),
             Progress::AdjustToMain(_round_trip_time) => self.phase = (now, Phase::AdjustToMain),
@@ -214,6 +223,7 @@ impl Display for Progress {
             Progress::PeerIps => write!(f, "Retrieving peer IPs"),
             Progress::KillswitchLockdown => write!(f, "Activating killswitch"),
             Progress::StaticWgTunnel(_) => write!(f, "Establishing static WireGuard tunnel"),
+            Progress::WgPumpStarted(_) => write!(f, "WireGuard pump started"),
             Progress::Ping => write!(f, "Verifying established connection"),
             Progress::AdjustToMain(round_trip_time) => {
                 write!(f, "Adjusting to main connection with RTT of {:?}", round_trip_time)

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -174,11 +174,21 @@ impl Runner {
             .await;
         let allowed_ips = parse_allowed_ips(self.wg_config.allowed_ips.as_deref());
         let interface = request_setup_tunnel(&registration, &self.wg_config, peer_ips.clone(), &results_sender).await?;
-        let (engine, tun_reader, tun_writer) = prepare_pump(&wg, &registration, allowed_ips).await?;
+        let (engine, tun_reader, tun_writer, wg_stats) = prepare_pump(&wg, &registration, allowed_ips).await?;
         let (read_half, write_half) = tokio::io::split(hopr_session);
         let net_tx = wg_tunnel::SessionSender::new(write_half);
         let net_rx = wg_tunnel::SessionReceiver::new(read_half);
-        self.spawn_pump_task(engine, net_tx, net_rx, tun_writer, tun_reader, &results_sender);
+        let _ = results_sender
+            .send(progress(Progress::WgPumpStarted(wg_stats.clone())))
+            .await;
+        self.spawn_pump_task(
+            engine,
+            net_tx,
+            net_rx,
+            (tun_writer, tun_reader),
+            wg_stats,
+            &results_sender,
+        );
 
         // 9. activate killswitch now that the interface name is known
         let _ = results_sender.send(progress(Progress::KillswitchLockdown)).await;
@@ -404,13 +414,22 @@ async fn request_setup_tunnel(
     )
 }
 
-/// Receive the TUN fd from root and build the pump's engine and TUN endpoints.
+/// Receive the TUN fd from root and build the pump's engine, TUN endpoints, and
+/// the tunnel stats handle the pump will record into as it runs.
 /// The network endpoint is supplied by the caller per the data-plane selection.
 async fn prepare_pump(
     wg: &WireGuard,
     registration: &Registration,
     allowed_ips: Vec<IpNetwork>,
-) -> Result<(wg_tunnel::WgTunnel, wg_tunnel::TunReader, wg_tunnel::TunWriter), Error> {
+) -> Result<
+    (
+        wg_tunnel::WgTunnel,
+        wg_tunnel::TunReader,
+        wg_tunnel::TunWriter,
+        Arc<wg_tunnel::WgTunnelStatsHandle>,
+    ),
+    Error,
+> {
     // The TUN fd is delivered out-of-band by root over the dedicated fd-passing
     // socket; block for it off the async runtime.
     let tun_fd = tokio::task::spawn_blocking(crate::socket::worker::recv_tun_fd)
@@ -429,8 +448,9 @@ async fn prepare_pump(
         &allowed_ips,
     )
     .map_err(|e| Error::Runtime(format!("failed to build wg tunnel: {e}")))?;
+    let stats = Arc::new(wg_tunnel::WgTunnelStatsHandle::new());
 
-    Ok((engine, tun_reader, tun_writer))
+    Ok((engine, tun_reader, tun_writer, stats))
 }
 
 impl Runner {
@@ -445,18 +465,19 @@ impl Runner {
         engine: wg_tunnel::WgTunnel,
         net_tx: NS,
         net_rx: NR,
-        tun_writer: wg_tunnel::TunWriter,
-        tun_reader: wg_tunnel::TunReader,
+        tun: (wg_tunnel::TunWriter, wg_tunnel::TunReader),
+        stats: Arc<wg_tunnel::WgTunnelStatsHandle>,
         results_sender: &mpsc::Sender<Results>,
     ) where
         NS: wg_tunnel::NetworkSender + 'static,
         NR: wg_tunnel::NetworkReceiver + 'static,
     {
+        let (tun_writer, tun_reader) = tun;
         let cancel = self.cancel.clone();
         let results_sender = results_sender.clone();
         self.pump_tasks.spawn(async move {
             let outcome = cancel
-                .run_until_cancelled(wg_tunnel::run(engine, net_tx, net_rx, tun_writer, tun_reader))
+                .run_until_cancelled(wg_tunnel::run(engine, net_tx, net_rx, tun_writer, tun_reader, stats))
                 .await;
             match pump_exit_reason(outcome) {
                 None => tracing::debug!("wg pump stopped (connection cancelled)"),

--- a/gnosis_vpn-lib/src/connection/up/runner.rs
+++ b/gnosis_vpn-lib/src/connection/up/runner.rs
@@ -157,6 +157,11 @@ impl Runner {
             configurator,
             metadata: session,
         } = open_spliced_wg_session(&self.hopr, &self.destination, &self.options, ping_surb, &results_sender).await?;
+        // Retain the configurator on `Up` (not just used once below) so core can
+        // reconfigure the SURB balancer later from live telemetry.
+        let _ = results_sender
+            .send(progress(Progress::SessionConfigurator(configurator.clone())))
+            .await;
 
         // 7. gather ips of all announced peers
         let _ = results_sender.send(progress(Progress::PeerIps)).await;
@@ -174,21 +179,11 @@ impl Runner {
             .await;
         let allowed_ips = parse_allowed_ips(self.wg_config.allowed_ips.as_deref());
         let interface = request_setup_tunnel(&registration, &self.wg_config, peer_ips.clone(), &results_sender).await?;
-        let (engine, tun_reader, tun_writer, wg_stats) = prepare_pump(&wg, &registration, allowed_ips).await?;
+        let (engine, tun_reader, tun_writer) = prepare_pump(&wg, &registration, allowed_ips).await?;
         let (read_half, write_half) = tokio::io::split(hopr_session);
         let net_tx = wg_tunnel::SessionSender::new(write_half);
         let net_rx = wg_tunnel::SessionReceiver::new(read_half);
-        let _ = results_sender
-            .send(progress(Progress::WgPumpStarted(wg_stats.clone())))
-            .await;
-        self.spawn_pump_task(
-            engine,
-            net_tx,
-            net_rx,
-            (tun_writer, tun_reader),
-            wg_stats,
-            &results_sender,
-        );
+        self.spawn_pump_task(engine, net_tx, net_rx, (tun_writer, tun_reader), &results_sender);
 
         // 9. activate killswitch now that the interface name is known
         let _ = results_sender.send(progress(Progress::KillswitchLockdown)).await;
@@ -414,22 +409,13 @@ async fn request_setup_tunnel(
     )
 }
 
-/// Receive the TUN fd from root and build the pump's engine, TUN endpoints, and
-/// the tunnel stats handle the pump will record into as it runs.
+/// Receive the TUN fd from root and build the pump's engine and TUN endpoints.
 /// The network endpoint is supplied by the caller per the data-plane selection.
 async fn prepare_pump(
     wg: &WireGuard,
     registration: &Registration,
     allowed_ips: Vec<IpNetwork>,
-) -> Result<
-    (
-        wg_tunnel::WgTunnel,
-        wg_tunnel::TunReader,
-        wg_tunnel::TunWriter,
-        Arc<wg_tunnel::WgTunnelStatsHandle>,
-    ),
-    Error,
-> {
+) -> Result<(wg_tunnel::WgTunnel, wg_tunnel::TunReader, wg_tunnel::TunWriter), Error> {
     // The TUN fd is delivered out-of-band by root over the dedicated fd-passing
     // socket; block for it off the async runtime.
     let tun_fd = tokio::task::spawn_blocking(crate::socket::worker::recv_tun_fd)
@@ -448,9 +434,8 @@ async fn prepare_pump(
         &allowed_ips,
     )
     .map_err(|e| Error::Runtime(format!("failed to build wg tunnel: {e}")))?;
-    let stats = Arc::new(wg_tunnel::WgTunnelStatsHandle::new());
 
-    Ok((engine, tun_reader, tun_writer, stats))
+    Ok((engine, tun_reader, tun_writer))
 }
 
 impl Runner {
@@ -466,7 +451,6 @@ impl Runner {
         net_tx: NS,
         net_rx: NR,
         tun: (wg_tunnel::TunWriter, wg_tunnel::TunReader),
-        stats: Arc<wg_tunnel::WgTunnelStatsHandle>,
         results_sender: &mpsc::Sender<Results>,
     ) where
         NS: wg_tunnel::NetworkSender + 'static,
@@ -475,9 +459,30 @@ impl Runner {
         let (tun_writer, tun_reader) = tun;
         let cancel = self.cancel.clone();
         let results_sender = results_sender.clone();
+
+        // Forward each stats sample into core's Results channel on a small
+        // dedicated task, so `wg_tunnel` stays unaware of core's Results enum.
+        // The forwarder exits on its own once the pump task below drops
+        // `sample_tx`, so it needs no separate cancellation wiring.
+        let (sample_tx, mut sample_rx) = mpsc::channel(4);
+        let forward_results_sender = results_sender.clone();
+        self.pump_tasks.spawn(async move {
+            while let Some(sample) = sample_rx.recv().await {
+                if forward_results_sender
+                    .send(Results::WgStatsSample(sample))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
         self.pump_tasks.spawn(async move {
             let outcome = cancel
-                .run_until_cancelled(wg_tunnel::run(engine, net_tx, net_rx, tun_writer, tun_reader, stats))
+                .run_until_cancelled(wg_tunnel::run(
+                    engine, net_tx, net_rx, tun_writer, tun_reader, sample_tx,
+                ))
                 .await;
             match pump_exit_reason(outcome) {
                 None => tracing::debug!("wg pump stopped (connection cancelled)"),

--- a/gnosis_vpn-lib/src/core/mod.rs
+++ b/gnosis_vpn-lib/src/core/mod.rs
@@ -22,7 +22,7 @@ use crate::event::{CoreToWorker, RequestToRoot, ResponseFromRoot, RunnerToRoot, 
 use crate::hopr::{self, Hopr, HoprError, config as hopr_config, identity};
 use crate::route_health::{self, RouteHealth};
 use crate::worker_params::{self, WorkerParams};
-use crate::{balance, log_output, peer, ticket_stats, wireguard};
+use crate::{balance, log_output, peer, ticket_stats, wg_tunnel, wireguard};
 
 pub(crate) mod runner;
 
@@ -956,6 +956,22 @@ impl Core {
                 }
             }
 
+            Results::WgStatsSample(sample) => match self.phase.clone() {
+                Phase::Connecting(mut conn) => {
+                    conn.record_wg_stats(sample.clone());
+                    self.maybe_adjust_session(&conn, &sample);
+                    self.phase = Phase::Connecting(conn);
+                }
+                Phase::Connected(mut conn) => {
+                    conn.record_wg_stats(sample.clone());
+                    self.maybe_adjust_session(&conn, &sample);
+                    self.phase = Phase::Connected(conn);
+                }
+                phase => {
+                    tracing::debug!(?phase, "received wg stats sample outside an active connection");
+                }
+            },
+
             Results::ConnectionRequestToRoot(respondable_request) => match respondable_request {
                 RunnerToRoot::KillswitchLockdown {
                     peer_ips,
@@ -1646,6 +1662,22 @@ impl Core {
                     .await;
             });
         }
+    }
+
+    /// Hook point for reacting to new WireGuard telemetry by adjusting the
+    /// active session's SURB balancer configuration. Policy (thresholds,
+    /// hysteresis/debounce, which `SurbBalancerConfig` field responds to which
+    /// telemetry trend) is intentionally not implemented here - this only wires
+    /// the mechanism (retained configurator + full sample history on `Up`) so
+    /// policy can be added later without further plumbing.
+    fn maybe_adjust_session(&self, conn: &connection::up::Up, _sample: &wg_tunnel::TunnelStatsSample) {
+        let Some(_configurator) = conn.session_configurator.as_ref() else {
+            return;
+        };
+        // TODO: derive an adjusted SurbBalancerConfig from conn.wg_stats (the
+        // retained history) and _sample, then call
+        // _configurator.update_surb_balancer_config(...). That call is safe to
+        // repeat - it fails gracefully if the session/manager is already gone.
     }
 
     fn spawn_tunnel_ping_probe(&self, results_sender: &mpsc::Sender<Results>) {

--- a/gnosis_vpn-lib/src/core/runner.rs
+++ b/gnosis_vpn-lib/src/core/runner.rs
@@ -98,6 +98,8 @@ pub(crate) enum Results {
     TunnelPingResult {
         rtt: Result<Duration, String>,
     },
+    /// A new WireGuard telemetry sample from the running pump.
+    WgStatsSample(crate::wg_tunnel::TunnelStatsSample),
     HealthCheck {
         id: String,
         outcome: HealthCheckOutcome,
@@ -627,6 +629,9 @@ impl Display for Results {
                 Ok(d) => write!(f, "TunnelPingResult: {:.1}ms", d.as_secs_f64() * 1000.0),
                 Err(err) => write!(f, "TunnelPingResult: Error({})", err),
             },
+            Results::WgStatsSample(sample) => {
+                write!(f, "WgStatsSample: tx={} rx={}", sample.tx_bytes, sample.rx_bytes)
+            }
             Results::QuerySafe { res } => match res {
                 Ok(Some(_)) => write!(f, "QuerySafe: Safe found"),
                 Ok(None) => write!(f, "QuerySafe: No safe found"),

--- a/gnosis_vpn-lib/src/wg_tunnel/mod.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/mod.rs
@@ -15,6 +15,7 @@
 
 mod pump;
 mod session;
+mod stats;
 #[cfg(unix)]
 mod tun;
 mod tunnel;
@@ -23,6 +24,7 @@ use neptun::noise::errors::WireGuardError;
 
 pub use pump::{NetworkReceiver, NetworkSender, PumpExit, TunReceiver, TunSender, run};
 pub use session::{SessionReceiver, SessionSender};
+pub use stats::{TunnelStatsSample, WgTunnelStats, WgTunnelStatsHandle};
 #[cfg(unix)]
 pub use tun::{PLATFORM_TUN_HEADER_LEN, TunReader, TunWriter, tun_endpoints};
 pub use tunnel::{Outputs, TimerTick, TunnelEngine, WgTunnel};

--- a/gnosis_vpn-lib/src/wg_tunnel/mod.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/mod.rs
@@ -24,7 +24,8 @@ use neptun::noise::errors::WireGuardError;
 
 pub use pump::{NetworkReceiver, NetworkSender, PumpExit, TunReceiver, TunSender, run};
 pub use session::{SessionReceiver, SessionSender};
-pub use stats::{TunnelStatsSample, WgTunnelStats, WgTunnelStatsHandle};
+pub(crate) use stats::HISTORY_CAPACITY;
+pub use stats::{TunnelStatsSample, WgTunnelStats};
 #[cfg(unix)]
 pub use tun::{PLATFORM_TUN_HEADER_LEN, TunReader, TunWriter, tun_endpoints};
 pub use tunnel::{Outputs, TimerTick, TunnelEngine, WgTunnel};

--- a/gnosis_vpn-lib/src/wg_tunnel/pump.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/pump.rs
@@ -9,11 +9,12 @@
 //! Writes are awaited inline, so a slow session applies real backpressure to the
 //! TUN reader - replacing the old UDP bridge's silent-drop ingress queue.
 
-use std::sync::Arc;
+use tokio::sync::mpsc;
+
 use std::time::Duration;
 
 use super::Error;
-use super::stats::WgTunnelStatsHandle;
+use super::stats::TunnelStatsSample;
 use super::tunnel::TunnelEngine;
 
 /// Cadence of NepTUN's timer processing, matching its own device loop.
@@ -146,7 +147,7 @@ pub async fn run<E, NS, NR, TS, TR>(
     mut net_rx: NR,
     mut tun_tx: TS,
     mut tun_rx: TR,
-    stats: Arc<WgTunnelStatsHandle>,
+    sample_sender: mpsc::Sender<TunnelStatsSample>,
 ) -> Result<PumpExit, Error>
 where
     E: TunnelEngine + Send + 'static,
@@ -240,7 +241,9 @@ where
                 }
                 timer_ticks += 1;
                 if timer_ticks.is_multiple_of(STATS_SAMPLE_EVERY_N_TICKS) {
-                    stats.record(engine.stats());
+                    // Best-effort: a full channel or closed receiver must never stall
+                    // this loop, so drop the sample rather than await capacity.
+                    let _ = sample_sender.try_send(engine.stats());
                 }
             }
         }
@@ -369,6 +372,11 @@ mod tests {
         p
     }
 
+    /// A throwaway stats sample sender; these tests don't inspect telemetry.
+    fn stats_sender() -> Sender<crate::wg_tunnel::TunnelStatsSample> {
+        channel(1).0
+    }
+
     #[tokio::test]
     async fn pump_sends_handshake_initiation_before_anything_else() {
         let engine = ScriptedEngine {
@@ -386,7 +394,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
         assert_eq!(net_out.recv().await, Some(vec![0xaa, 0xbb, 0xcc]));
         handle.abort();
@@ -415,7 +423,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
         net_in_tx.send(vec![0x01, 0x02]).await.unwrap();
         assert_eq!(tun_out.recv().await, Some(packet));
@@ -439,7 +447,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
         // First datagram out is the handshake init; then our echoed packet.
         assert_eq!(net_out.recv().await, Some(vec![0xff]));
@@ -469,7 +477,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
         assert_eq!(net_out.recv().await, Some(vec![1])); // handshake init
         net_in_tx.send(vec![0xde, 0xad]).await.unwrap(); // dropped datagram
@@ -503,7 +511,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
         // Feed more than a full window; every datagram fails, so the guard fires.
         for _ in 0..(super::DECAP_FAILURE_WINDOW + 16) {
@@ -537,7 +545,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
-                Arc::new(WgTunnelStatsHandle::new()),
+                stats_sender(),
             ),
         )
         .await
@@ -566,7 +574,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         )
         .await
         .expect_err("a wedged write must be fatal");
@@ -597,7 +605,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
-                Arc::new(WgTunnelStatsHandle::new()),
+                stats_sender(),
             ),
         )
         .await
@@ -632,7 +640,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
-                Arc::new(WgTunnelStatsHandle::new()),
+                stats_sender(),
             ),
         )
         .await
@@ -661,7 +669,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
-                Arc::new(WgTunnelStatsHandle::new()),
+                stats_sender(),
             ),
         )
         .await
@@ -690,7 +698,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
-                Arc::new(WgTunnelStatsHandle::new()),
+                stats_sender(),
             ),
         )
         .await
@@ -755,7 +763,7 @@ mod tests {
             ChannelRx(to_client_rx),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in_rx),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
 
         // Inject an outbound packet from the "applications" side of the TUN.
@@ -822,7 +830,7 @@ mod tests {
             net_rx,
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in_rx),
-            Arc::new(WgTunnelStatsHandle::new()),
+            stats_sender(),
         ));
 
         // Drive the server inline over the raw session bytes so ordering is fully

--- a/gnosis_vpn-lib/src/wg_tunnel/pump.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/pump.rs
@@ -9,13 +9,21 @@
 //! Writes are awaited inline, so a slow session applies real backpressure to the
 //! TUN reader - replacing the old UDP bridge's silent-drop ingress queue.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::Error;
+use super::stats::WgTunnelStatsHandle;
 use super::tunnel::TunnelEngine;
 
 /// Cadence of NepTUN's timer processing, matching its own device loop.
 const TIMER_PERIOD: Duration = Duration::from_millis(250);
+
+/// Sample tunnel stats every Nth timer tick rather than every tick: `rtt_ms`
+/// and handshake age barely change between WireGuard handshakes (~2 min
+/// apart), so sampling every 250ms would mostly record duplicates. Every 16th
+/// tick is ~4s.
+const STATS_SAMPLE_EVERY_N_TICKS: u32 = 16;
 
 /// Longest a single session/TUN write may block before the pump treats the
 /// endpoint as wedged and tears down so the connection can be re-established.
@@ -138,6 +146,7 @@ pub async fn run<E, NS, NR, TS, TR>(
     mut net_rx: NR,
     mut tun_tx: TS,
     mut tun_rx: TR,
+    stats: Arc<WgTunnelStatsHandle>,
 ) -> Result<PumpExit, Error>
 where
     E: TunnelEngine + Send + 'static,
@@ -162,6 +171,7 @@ where
     // replay), so tear down for a fresh session rather than degrade silently.
     let mut decap_window_total: u32 = 0;
     let mut decap_window_failures: u32 = 0;
+    let mut timer_ticks: u32 = 0;
 
     loop {
         tokio::select! {
@@ -227,6 +237,10 @@ where
                     if let Sent::Closed = send_network(&mut net_tx, &datagram).await? {
                         return Ok(PumpExit::NetworkClosed);
                     }
+                }
+                timer_ticks += 1;
+                if timer_ticks.is_multiple_of(STATS_SAMPLE_EVERY_N_TICKS) {
+                    stats.record(engine.stats());
                 }
             }
         }
@@ -343,6 +357,9 @@ mod tests {
         fn update_timers(&mut self) -> Result<TimerTick, Error> {
             Ok(self.ticks.pop_front().unwrap_or_default())
         }
+        fn stats(&self) -> crate::wg_tunnel::TunnelStatsSample {
+            crate::wg_tunnel::TunnelStatsSample::default()
+        }
     }
 
     fn ipv4_packet(src: [u8; 4], dst: [u8; 4]) -> Vec<u8> {
@@ -369,6 +386,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
         assert_eq!(net_out.recv().await, Some(vec![0xaa, 0xbb, 0xcc]));
         handle.abort();
@@ -397,6 +415,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
         net_in_tx.send(vec![0x01, 0x02]).await.unwrap();
         assert_eq!(tun_out.recv().await, Some(packet));
@@ -420,6 +439,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
         // First datagram out is the handshake init; then our echoed packet.
         assert_eq!(net_out.recv().await, Some(vec![0xff]));
@@ -449,6 +469,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
         assert_eq!(net_out.recv().await, Some(vec![1])); // handshake init
         net_in_tx.send(vec![0xde, 0xad]).await.unwrap(); // dropped datagram
@@ -482,6 +503,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
         // Feed more than a full window; every datagram fails, so the guard fires.
         for _ in 0..(super::DECAP_FAILURE_WINDOW + 16) {
@@ -515,6 +537,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
+                Arc::new(WgTunnelStatsHandle::new()),
             ),
         )
         .await
@@ -543,6 +566,7 @@ mod tests {
             ChannelRx(net_in),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in),
+            Arc::new(WgTunnelStatsHandle::new()),
         )
         .await
         .expect_err("a wedged write must be fatal");
@@ -573,6 +597,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
+                Arc::new(WgTunnelStatsHandle::new()),
             ),
         )
         .await
@@ -607,6 +632,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
+                Arc::new(WgTunnelStatsHandle::new()),
             ),
         )
         .await
@@ -635,6 +661,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
+                Arc::new(WgTunnelStatsHandle::new()),
             ),
         )
         .await
@@ -663,6 +690,7 @@ mod tests {
                 ChannelRx(net_in),
                 ChannelTx(tun_out_tx),
                 ChannelRx(tun_in),
+                Arc::new(WgTunnelStatsHandle::new()),
             ),
         )
         .await
@@ -727,6 +755,7 @@ mod tests {
             ChannelRx(to_client_rx),
             ChannelTx(tun_out_tx),
             ChannelRx(tun_in_rx),
+            Arc::new(WgTunnelStatsHandle::new()),
         ));
 
         // Inject an outbound packet from the "applications" side of the TUN.
@@ -787,7 +816,14 @@ mod tests {
         let (tun_in_tx, tun_in_rx) = channel::<Vec<u8>>(16);
         let (tun_out_tx, mut tun_out_rx) = channel::<Vec<u8>>(16);
 
-        let pump = tokio::spawn(run(client, net_tx, net_rx, ChannelTx(tun_out_tx), ChannelRx(tun_in_rx)));
+        let pump = tokio::spawn(run(
+            client,
+            net_tx,
+            net_rx,
+            ChannelTx(tun_out_tx),
+            ChannelRx(tun_in_rx),
+            Arc::new(WgTunnelStatsHandle::new()),
+        ));
 
         // Drive the server inline over the raw session bytes so ordering is fully
         // controlled and each `recv` returns exactly one datagram.

--- a/gnosis_vpn-lib/src/wg_tunnel/stats.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/stats.rs
@@ -10,6 +10,8 @@ use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
+use crate::serde_utils;
+
 /// How many samples to retain. At the pump's sampling cadence this covers
 /// roughly the last 20 minutes.
 const HISTORY_CAPACITY: usize = 300;
@@ -22,10 +24,12 @@ const HISTORY_CAPACITY: usize = 300;
 /// handshake, not "now".
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TunnelStatsSample {
+    #[serde(with = "serde_utils::system_time")]
     pub at: SystemTime,
     pub tx_bytes: u64,
     pub rx_bytes: u64,
     pub rtt_ms: Option<u32>,
+    #[serde(with = "serde_utils::opt_duration_ms")]
     pub time_since_last_handshake: Option<Duration>,
     pub estimated_loss: f32,
 }

--- a/gnosis_vpn-lib/src/wg_tunnel/stats.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/stats.rs
@@ -1,0 +1,126 @@
+//! Snapshot and bounded history of NepTUN's own tunnel counters and timers.
+//!
+//! `Tunn::stats()` already tracks everything here internally; the pump loop
+//! just samples it periodically and keeps a short rolling window for the
+//! `nerd-stats` CLI command to read.
+
+use serde::{Deserialize, Serialize};
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+/// How many samples to retain. At the pump's sampling cadence this covers
+/// roughly the last 20 minutes.
+const HISTORY_CAPACITY: usize = 300;
+
+/// A point-in-time snapshot of NepTUN's internal tunnel counters and timers.
+///
+/// `rtt_ms` and `time_since_last_handshake` only advance on a WireGuard
+/// handshake, which recurs roughly every two minutes on an active tunnel
+/// (`REKEY_AFTER_TIME` in neptun) - they reflect the state as of the last
+/// handshake, not "now".
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TunnelStatsSample {
+    pub at: SystemTime,
+    pub tx_bytes: u64,
+    pub rx_bytes: u64,
+    pub rtt_ms: Option<u32>,
+    pub time_since_last_handshake: Option<Duration>,
+    pub estimated_loss: f32,
+}
+
+impl Default for TunnelStatsSample {
+    fn default() -> Self {
+        Self {
+            at: SystemTime::UNIX_EPOCH,
+            tx_bytes: 0,
+            rx_bytes: 0,
+            rtt_ms: None,
+            time_since_last_handshake: None,
+            estimated_loss: 0.0,
+        }
+    }
+}
+
+/// The latest sample plus a bounded window of history, oldest first.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct WgTunnelStats {
+    pub current: Option<TunnelStatsSample>,
+    pub history: Vec<TunnelStatsSample>,
+}
+
+/// Shared handle the pump loop records into and the query path reads from.
+///
+/// Deliberately separate from the engine's own state (see `pump`'s module doc
+/// on owning the engine without a mutex): this lock is only touched a few
+/// times a minute, never on the packet hot path, and its critical section
+/// never panics, so a poisoned lock is recovered rather than propagated.
+#[derive(Debug, Default)]
+pub struct WgTunnelStatsHandle(Mutex<VecDeque<TunnelStatsSample>>);
+
+impl WgTunnelStatsHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a new sample, evicting the oldest once at capacity.
+    pub fn record(&self, sample: TunnelStatsSample) {
+        let mut history = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        if history.len() >= HISTORY_CAPACITY {
+            history.pop_front();
+        }
+        history.push_back(sample);
+    }
+
+    /// Clone out the latest sample plus the full retained history.
+    pub fn snapshot(&self) -> WgTunnelStats {
+        let history = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        WgTunnelStats {
+            current: history.back().cloned(),
+            history: history.iter().cloned().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(tx_bytes: u64) -> TunnelStatsSample {
+        TunnelStatsSample {
+            tx_bytes,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn snapshot_is_empty_before_any_record() {
+        let handle = WgTunnelStatsHandle::new();
+        let stats = handle.snapshot();
+        assert!(stats.current.is_none());
+        assert!(stats.history.is_empty());
+    }
+
+    #[test]
+    fn record_appends_and_snapshot_reflects_latest() {
+        let handle = WgTunnelStatsHandle::new();
+        handle.record(sample(1));
+        handle.record(sample(2));
+        let stats = handle.snapshot();
+        assert_eq!(stats.current, Some(sample(2)));
+        assert_eq!(stats.history, vec![sample(1), sample(2)]);
+    }
+
+    #[test]
+    fn record_evicts_oldest_past_capacity() {
+        let handle = WgTunnelStatsHandle::new();
+        for i in 0..(HISTORY_CAPACITY + 5) {
+            handle.record(sample(i as u64));
+        }
+        let stats = handle.snapshot();
+        assert_eq!(stats.history.len(), HISTORY_CAPACITY);
+        assert_eq!(stats.history.first().unwrap().tx_bytes, 5);
+        assert_eq!(stats.history.last().unwrap().tx_bytes, (HISTORY_CAPACITY + 4) as u64);
+    }
+}

--- a/gnosis_vpn-lib/src/wg_tunnel/stats.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/stats.rs
@@ -1,20 +1,18 @@
-//! Snapshot and bounded history of NepTUN's own tunnel counters and timers.
+//! Snapshot type for NepTUN's own tunnel counters and timers.
 //!
 //! `Tunn::stats()` already tracks everything here internally; the pump loop
-//! just samples it periodically and keeps a short rolling window for the
-//! `nerd-stats` CLI command to read.
+//! just samples it periodically and forwards it onward for `core` to retain a
+//! short rolling window that the `nerd-stats` CLI command reads.
 
 use serde::{Deserialize, Serialize};
 
-use std::collections::VecDeque;
-use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 use crate::serde_utils;
 
-/// How many samples to retain. At the pump's sampling cadence this covers
-/// roughly the last 20 minutes.
-const HISTORY_CAPACITY: usize = 300;
+/// How many samples `core` retains per connection. At the pump's sampling
+/// cadence this covers roughly the last 20 minutes.
+pub(crate) const HISTORY_CAPACITY: usize = 300;
 
 /// A point-in-time snapshot of NepTUN's internal tunnel counters and timers.
 ///
@@ -52,79 +50,4 @@ impl Default for TunnelStatsSample {
 pub struct WgTunnelStats {
     pub current: Option<TunnelStatsSample>,
     pub history: Vec<TunnelStatsSample>,
-}
-
-/// Shared handle the pump loop records into and the query path reads from.
-///
-/// Deliberately separate from the engine's own state (see `pump`'s module doc
-/// on owning the engine without a mutex): this lock is only touched a few
-/// times a minute, never on the packet hot path, and its critical section
-/// never panics, so a poisoned lock is recovered rather than propagated.
-#[derive(Debug, Default)]
-pub struct WgTunnelStatsHandle(Mutex<VecDeque<TunnelStatsSample>>);
-
-impl WgTunnelStatsHandle {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Record a new sample, evicting the oldest once at capacity.
-    pub fn record(&self, sample: TunnelStatsSample) {
-        let mut history = self.0.lock().unwrap_or_else(|e| e.into_inner());
-        if history.len() >= HISTORY_CAPACITY {
-            history.pop_front();
-        }
-        history.push_back(sample);
-    }
-
-    /// Clone out the latest sample plus the full retained history.
-    pub fn snapshot(&self) -> WgTunnelStats {
-        let history = self.0.lock().unwrap_or_else(|e| e.into_inner());
-        WgTunnelStats {
-            current: history.back().cloned(),
-            history: history.iter().cloned().collect(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn sample(tx_bytes: u64) -> TunnelStatsSample {
-        TunnelStatsSample {
-            tx_bytes,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn snapshot_is_empty_before_any_record() {
-        let handle = WgTunnelStatsHandle::new();
-        let stats = handle.snapshot();
-        assert!(stats.current.is_none());
-        assert!(stats.history.is_empty());
-    }
-
-    #[test]
-    fn record_appends_and_snapshot_reflects_latest() {
-        let handle = WgTunnelStatsHandle::new();
-        handle.record(sample(1));
-        handle.record(sample(2));
-        let stats = handle.snapshot();
-        assert_eq!(stats.current, Some(sample(2)));
-        assert_eq!(stats.history, vec![sample(1), sample(2)]);
-    }
-
-    #[test]
-    fn record_evicts_oldest_past_capacity() {
-        let handle = WgTunnelStatsHandle::new();
-        for i in 0..(HISTORY_CAPACITY + 5) {
-            handle.record(sample(i as u64));
-        }
-        let stats = handle.snapshot();
-        assert_eq!(stats.history.len(), HISTORY_CAPACITY);
-        assert_eq!(stats.history.first().unwrap().tx_bytes, 5);
-        assert_eq!(stats.history.last().unwrap().tx_bytes, (HISTORY_CAPACITY + 4) as u64);
-    }
 }

--- a/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
@@ -9,6 +9,7 @@
 //! plumbing involved.
 
 use std::net::IpAddr;
+use std::time::SystemTime;
 
 use ipnetwork::IpNetwork;
 use neptun::noise::errors::WireGuardError;
@@ -16,6 +17,7 @@ use neptun::noise::{Tunn, TunnResult};
 use x25519_dalek::{PublicKey, StaticSecret};
 
 use super::Error;
+use super::stats::TunnelStatsSample;
 use crate::wireguard;
 
 /// WireGuard's per-datagram overhead over the plaintext: a 16-byte data-message
@@ -67,6 +69,9 @@ pub trait TunnelEngine {
     fn decapsulate(&mut self, datagram: &[u8]) -> Result<Outputs, Error>;
     /// Advance WireGuard's timers, emitting any due datagrams.
     fn update_timers(&mut self) -> Result<TimerTick, Error>;
+    /// Snapshot NepTUN's own tunnel counters and timers (bytes, handshake age,
+    /// rtt, loss estimate).
+    fn stats(&self) -> TunnelStatsSample;
 }
 
 /// One decapsulate step, decoupled from the scratch buffer's borrow so the drain
@@ -208,6 +213,18 @@ impl TunnelEngine for WgTunnel {
             }),
             TunnResult::Err(e) => Err(Error::WireGuard(e)),
             TunnResult::WriteToTunnel(..) => Err(Error::Unexpected("update_timers wrote to tunnel")),
+        }
+    }
+
+    fn stats(&self) -> TunnelStatsSample {
+        let (time_since_last_handshake, tx_bytes, rx_bytes, estimated_loss, rtt_ms) = self.tunn.stats();
+        TunnelStatsSample {
+            at: SystemTime::now(),
+            tx_bytes,
+            rx_bytes,
+            rtt_ms,
+            time_since_last_handshake,
+            estimated_loss,
         }
     }
 }

--- a/gnosis_vpn-lib/tests/socket_types.rs
+++ b/gnosis_vpn-lib/tests/socket_types.rs
@@ -15,6 +15,7 @@ use gnosis_vpn_lib::connection::{DownPhase, UpPhase};
 use gnosis_vpn_lib::route_health::{
     ExitHealth, Health, LoadAvg, RouteHealthState, Slots, UnrecoverableReason, Versions,
 };
+use gnosis_vpn_lib::wg_tunnel::{TunnelStatsSample, WgTunnelStats};
 
 // This function exists only to force the compiler to verify that every type in
 // the socket API surface is reachable from outside the crate. It is never called.
@@ -43,6 +44,8 @@ fn assert_types_are_accessible() {
     let _: TicketStats;
     let _: NerdStatsResponse;
     let _: ConnStats;
+    let _: WgTunnelStats;
+    let _: TunnelStatsSample;
     let _: ActiveSession;
     let _: BalanceResponse;
     let _: ChannelOut;


### PR DESCRIPTION
…via nerd-stats

Samples neptun's existing Tunn::stats() every ~4s from the pump loop into a bounded in-memory ring buffer, threaded through Up.wg_stats and exposed on ConnStats/NerdStatsResponse. rtt/handshake age are labeled "as of last handshake" since WireGuard only updates them on a handshake (~120s cadence).