### PR TITLE
chore(deps): move onto edge-client main and the released HOPR crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -865,7 +865,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.1.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=9e24e8b9177e85f1e752010c43ab792d8ed93c3f#9e24e8b9177e85f1e752010c43ab792d8ed93c3f"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=7d4de8ecfdc22bab2f7bb9674beccbafa053f56b#7d4de8ecfdc22bab2f7bb9674beccbafa053f56b"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4061,7 +4061,8 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "2.0.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=ee65b340cf09fd6031735477cc1171d7610694a3#ee65b340cf09fd6031735477cc1171d7610694a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b888d2f2d08002d003db1789f732c812ebe2709375780cc6b12eeba09930452c"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4098,7 +4099,8 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a053b62b7fb08927b8bc1f271018c122151d8bafbdcd3e0081a09322b13fcdae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4128,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4146,7 +4148,8 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7985d0e77c83e9ae107dcc53012eeb736b83edeb83cf3522a3d1b7ab1e66fa9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4163,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4194,7 +4197,8 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1104069d205e792651562e8648e2403f815169c4c822ba00678b82fa1911fa2e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4214,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4227,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4256,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4287,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4302,7 +4306,8 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.28.0"
-source = "git+https://github.com/hoprnet/hopr-strategy?rev=272f41000cd6e1bec9e2d08e2cd85f37aa804ea9#272f41000cd6e1bec9e2d08e2cd85f37aa804ea9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b80cfdf4632f8ffc73ad4d5c9bfadaa14783c7f4bf44c7ac7e9940fcd03137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4330,7 +4335,8 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbedcb10d008c7a1831ceb89c213ab2a0242405e24d99886839553fca725ca89"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4352,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.48.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4395,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4412,7 +4418,8 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e9a987efe3013cf7f3809d5f87aec29d5588a695a6af718dd406f5d0f5806b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4433,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4459,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.28.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4491,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4567,7 +4574,8 @@ dependencies = [
 [[package]]
 name = "hopr-utilities"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hopr-utilities?rev=68e648be4aa9f1442c75df4006a53db414932f7e#68e648be4aa9f1442c75df4006a53db414932f7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9a46fe251a9aa6ee3ab7e2edd7720ac6f09ad4f01566dd6c056913615cc43"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4600,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6237,7 +6245,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7160,7 +7168,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7172,7 +7180,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "socket2 0.6.5",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7660,7 +7668,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7719,7 +7727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8347,7 +8355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8582,7 +8590,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9394,7 +9402,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.5", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "9e24e8b9177e85f1e752010c43ab792d8ed93c3f", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "7d4de8ecfdc22bab2f7bb9674beccbafa053f56b", features = [
   "blokli",
   "telemetry",
 ] }
@@ -36,8 +36,8 @@ futures-util = "~0.3.33"
 # Cargo treats `?branch=X#sha` and `?rev=sha` as distinct sources even for byte-identical
 # commits -- mixing the two builds hoprnet twice and fails with `expected
 # hopr_lib::HoprSessionClientConfig, found HoprSessionClientConfig`. Keep both entries in the
-# same form. Testing pin: repoint to `branch = "release/4.0"` once the upstream stack lands.
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/test/transport/return-routing-origination-stall", features = [
+# same form.
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "release/4.0", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "~0.1.4"

--- a/gnosis_vpn-lib/src/balance.rs
+++ b/gnosis_vpn-lib/src/balance.rs
@@ -156,7 +156,11 @@ pub struct BalanceRecommendation {
     /// Total wxHOPR to fund: channel stakes plus the fee to start.
     #[serde(with = "serde_utils::balance")]
     pub wxhopr: Balance<WxHOPR>,
-    /// Recommended xDai balance for gas (flat, one [`Self::xdai_fee_per_tx`]).
+    /// Recommended xDai balance for gas: the total amount to fund the node with.
+    ///
+    /// Not [`Self::xdai_fee_per_tx`], which is a ceiling on a single transaction rather than
+    /// expected spend -- funding one transaction's worth would leave the node unable to finish
+    /// starting up.
     #[serde(with = "serde_utils::balance")]
     pub xdai: Balance<XDai>,
     /// wxHOPR needed to stake the missing channels.
@@ -178,7 +182,7 @@ impl From<edgli::strategy::BalanceRecommendation> for BalanceRecommendation {
     fn from(rec: edgli::strategy::BalanceRecommendation) -> Self {
         BalanceRecommendation {
             wxhopr: rec.total_wxhopr(),
-            xdai: rec.xdai_fee_per_tx,
+            xdai: rec.xdai_fund_amount,
             channel_stakes: rec.channel_stakes,
             fee_to_start: rec.fee_to_start,
             txs_to_start: rec.txs_to_start,
@@ -395,10 +399,15 @@ mod tests {
             fee_to_start: Balance::<WxHOPR>::from(10_000u64),
             txs_to_start: 3,
             xdai_fee_per_tx: Balance::<XDai>::from(100u64),
+            xdai_fund_amount: Balance::<XDai>::from(5_000u64),
         };
         let mirrored: BalanceRecommendation = rec.into();
         assert_eq!(mirrored.wxhopr, Balance::<WxHOPR>::from(10_800u64));
-        assert_eq!(mirrored.xdai, Balance::<XDai>::from(100u64));
+        assert_eq!(
+            mirrored.xdai,
+            Balance::<XDai>::from(5_000u64),
+            "xdai must mirror the fund amount, not one transaction's fee ceiling"
+        );
         assert_eq!(mirrored.channel_stakes, Balance::<WxHOPR>::from(800u64));
         assert_eq!(mirrored.fee_to_start, Balance::<WxHOPR>::from(10_000u64));
         assert_eq!(mirrored.txs_to_start, 3);

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,18 +33,10 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=9e24e8b9177e85f1e752010c43ab792d8ed93c3f#9e24e8b9177e85f1e752010c43ab792d8ed93c3f" =
-      "sha256-SC+ch8C7m7lYQjOh8kwKTgiX2UherAvp+6jr4Z88fQ4=";
-    "git+https://github.com/hoprnet/hopr-api?rev=ee65b340cf09fd6031735477cc1171d7610694a3#ee65b340cf09fd6031735477cc1171d7610694a3" =
-      "sha256-Tevhabmz4XfQTBXGLbUmW3uV+7kpbPVnWgFdsYstJl8=";
-    "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44" =
-      "sha256-LoMm1ZjhSWu/UPTHMfrPOKQy2XrHadOhbmKwtF9bOlI=";
-    "git+https://github.com/hoprnet/hopr-strategy?rev=272f41000cd6e1bec9e2d08e2cd85f37aa804ea9#272f41000cd6e1bec9e2d08e2cd85f37aa804ea9" =
-      "sha256-K4Jtm3TJmNh5rlPlrT0ye66UEQ78OqtwDw2wOs8lb5A=";
-    "git+https://github.com/hoprnet/hopr-utilities?rev=68e648be4aa9f1442c75df4006a53db414932f7e#68e648be4aa9f1442c75df4006a53db414932f7e" =
-      "sha256-1hYv2N2HjE7sTLbw5DXOQLOvae9dYR0iwSl6OsCUQhE=";
-    "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Ftransport%2Freturn-routing-origination-stall#66dc5d19e1c4fc7fd4e9dbfa064004e0060b6fc9" =
-      "sha256-voL5h7BHhvDIHqhVmQ43t8xXtD+PXOWt/aWpcBHLPL8=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=7d4de8ecfdc22bab2f7bb9674beccbafa053f56b#7d4de8ecfdc22bab2f7bb9674beccbafa053f56b" =
+      "sha256-Ry0ifL7BuiOkCMmSR2mBsagBD0yolwQ2p8o/MtVy/WI=";
+    "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26" =
+      "sha256-JXtFX7+TUKMajfmmvaF1hcOQ2Y8li7gpoX/eb9LM+3c=";
   };
 
   builders = nixLib.mkRustBuilders {


### PR DESCRIPTION
Takes `edgli` from edge-client `main`, which has completed its migration onto the published HOPR crates. The lock goes from **six** hoprnet-organisation git sources down to **one**.

`hopr-lib` is the exception and stays a git dependency, because it is not a crates.io crate. It tracks `release/4.0`, which now carries the whole merged graph-presence and session stack — so `hopr-utils-session` moves to the same branch. **Keeping both on the same branch, in the same pin form, is what stops Cargo resolving hoprnet twice**: `?branch=X#sha` and `?rev=sha` are distinct sources to Cargo even for byte-identical commits, and mixing them previously produced eight `expected hopr_lib::HoprSessionClientConfig, found HoprSessionClientConfig` errors.

## One behaviour change, not just a repoint

`BalanceRecommendation.xdai` now mirrors upstream `xdai_fund_amount` instead of `xdai_fee_per_tx`.

edge-client added that field to separate two things this mapping had conflated. `xdai_fee_per_tx` is documented as *"a ceiling on what one transaction may cost, not expected spend"*; `xdai_fund_amount` is *"what to actually fund the node with"*. Funding a node with one transaction's gas ceiling leaves it unable to finish starting up, which is what the upstream change set out to fix. The mapping, the field doc and the test assertion all move together, so the test now fails if the two are swapped back.

## Also

`outputHashes` in `nix/gnosisvpn.nix` drops the four entries whose sources no longer exist and takes fresh hashes for the two that moved. Verified the key set matches `Cargo.lock`'s git sources exactly — no missing hash, no stale extra.