### PR TITLE
fix(ctl): use 3-decimal precision for handshake age, matching NepTUN'…

### DIFF
--- a/gnosis_vpn-ctl/src/main.rs
+++ b/gnosis_vpn-ctl/src/main.rs
@@ -549,6 +549,13 @@ fn print_connected_stats(stats: &command::ConnStats) {
     println!("{str_resp}");
 }
 
+fn format_handshake_age(d: Duration) -> String {
+    // drop sub-second precision so humantime output skips ms/us
+    let secs = Duration::from_secs(d.as_secs());
+    // 3 decimals: NepTUN's tick granularity (pump.rs TIMER_PERIOD)
+    format!("{:.3}s ({})", d.as_secs_f64(), humantime::format_duration(secs))
+}
+
 /// Render the last WireGuard tunnel stats sample, if the pump has started and
 /// recorded one. `rtt`/handshake age are labeled "as of last handshake", not
 /// "current" - WireGuard only updates them on a handshake, which recurs every
@@ -560,7 +567,7 @@ fn print_wg_tunnel_stats(stats: &command::ConnStats) -> String {
     let rtt = current.rtt_ms.map(|ms| format!("{ms}ms")).unwrap_or("--".to_string());
     let handshake_age = current
         .time_since_last_handshake
-        .map(|d| format!("{:.2}s ({})", d.as_secs_f64(), humantime::format_duration(d)))
+        .map(format_handshake_age)
         .unwrap_or("--".to_string());
     format!(
         "---\nTunnel RTT (as of last handshake): {rtt}\nLast handshake: {handshake_age} ago\nTx bytes: {} ({})\nRx bytes: {} ({})\nEstimated loss: {:.1}%\n",


### PR DESCRIPTION
…s tick