### PR TITLE
fix(wireguard): enable 25s persistent keepalive on the NepTUN tunnel

### DIFF
--- a/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
@@ -24,14 +24,7 @@ use crate::wireguard;
 /// header plus the 16-byte Poly1305 tag.
 const WG_DATA_OVERHEAD: usize = 32;
 
-/// Emit a WireGuard keepalive after this many seconds of tunnel idleness.
-///
-/// The tunnel's egress rides a chain of UDP flows (local session socket -> HOPR
-/// QUIC/UDP to the entry node -> mixnet -> exit -> the real WireGuard server),
-/// each of which is subject to NAT/conntrack idle expiry along the path. Without a
-/// keepalive an idle period silently drops those mappings and strands the return
-/// path. 25 s is WireGuard's own recommended value: comfortably under the common
-/// 30 s NAT UDP idle floor while adding negligible traffic.
+/// Keeps the multi-hop UDP egress chain (local→HOPR→mixnet→exit→WG server) alive across NAT/conntrack idle timeouts; 25 s is under the common 30 s floor.
 const WG_PERSISTENT_KEEPALIVE_SECS: u16 = 25;
 
 /// Scratch buffer for a single NepTUN output. It must strictly dominate any

--- a/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
@@ -24,6 +24,16 @@ use crate::wireguard;
 /// header plus the 16-byte Poly1305 tag.
 const WG_DATA_OVERHEAD: usize = 32;
 
+/// Emit a WireGuard keepalive after this many seconds of tunnel idleness.
+///
+/// The tunnel's egress rides a chain of UDP flows (local session socket -> HOPR
+/// QUIC/UDP to the entry node -> mixnet -> exit -> the real WireGuard server),
+/// each of which is subject to NAT/conntrack idle expiry along the path. Without a
+/// keepalive an idle period silently drops those mappings and strands the return
+/// path. 25 s is WireGuard's own recommended value: comfortably under the common
+/// 30 s NAT UDP idle floor while adding negligible traffic.
+const WG_PERSISTENT_KEEPALIVE_SECS: u16 = 25;
+
 /// Scratch buffer for a single NepTUN output. It must strictly dominate any
 /// packet the pump can hand to `encapsulate`: the pump reads up to `MAX_FRAME`
 /// bytes per packet, and encapsulation adds up to `WG_DATA_OVERHEAD`, so
@@ -109,9 +119,11 @@ impl WgTunnel {
             Some(psk) => Some(wireguard::decode_key32(psk)?),
             None => None,
         };
-        // index 0, no persistent keepalive, no rate limiter - single-peer client,
-        // matching the wg-quick config we are replacing.
-        let tunn = Tunn::new(secret, peer, preshared_key, None, 0, None).map_err(Error::Tunn)?;
+        // index 0, no rate limiter - single-peer client. A persistent keepalive
+        // keeps the tunnel's NAT/conntrack path warm across idle gaps (see
+        // WG_PERSISTENT_KEEPALIVE_SECS).
+        let tunn =
+            Tunn::new(secret, peer, preshared_key, Some(WG_PERSISTENT_KEEPALIVE_SECS), 0, None).map_err(Error::Tunn)?;
         Ok(Self {
             tunn,
             scratch: vec![0u8; SCRATCH_LEN].into_boxed_slice(),

--- a/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
+++ b/gnosis_vpn-lib/src/wg_tunnel/tunnel.rs
@@ -112,9 +112,6 @@ impl WgTunnel {
             Some(psk) => Some(wireguard::decode_key32(psk)?),
             None => None,
         };
-        // index 0, no rate limiter - single-peer client. A persistent keepalive
-        // keeps the tunnel's NAT/conntrack path warm across idle gaps (see
-        // WG_PERSISTENT_KEEPALIVE_SECS).
         let tunn =
             Tunn::new(secret, peer, preshared_key, Some(WG_PERSISTENT_KEEPALIVE_SECS), 0, None).map_err(Error::Tunn)?;
         Ok(Self {


### PR DESCRIPTION
## Summary

The NepTUN WireGuard data plane was built with **no persistent keepalive** — `Tunn::new`'s 4th argument was `None`, carried over from the old wg-quick config during the user-space WireGuard migration (#656).

The tunnel's egress is not a direct WireGuard-to-server UDP flow. It rides a **chain of UDP flows**, each subject to independent NAT/conntrack idle expiry:

```
local session socket → HOPR QUIC/UDP to entry node → mixnet → exit → real WireGuard server
```

With no keepalive, any idle gap can silently drop a NAT/conntrack mapping somewhere along that path and strand the return path — the tunnel appears up but no traffic flows until it is torn down and re-established. This is especially likely in multi-hop network environments (e.g. QubesOS, where traffic crosses `sys-firewall`/`sys-net`) and behind consumer/carrier-grade NAT.

This change sets a **25s persistent keepalive** — WireGuard's own recommended value, comfortably under the common 30s NAT UDP idle floor — added via a named `WG_PERSISTENT_KEEPALIVE_SECS` constant so the rationale lives next to the value.