### PR TITLE
feat(session): request Datagram capability on the UDP-like session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.1.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=4ba1e5977520828cec40f426c0e0a27d6dae71f7#4ba1e5977520828cec40f426c0e0a27d6dae71f7"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=d1e03789dafb415a975ad437fc14d894b3dabb2c#d1e03789dafb415a975ad437fc14d894b3dabb2c"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4400,8 +4400,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.48.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+version = "0.48.1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4508,8 +4508,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.28.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+version = "0.29.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
+source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#08d777e442c251bbd2dc55e36434dbd4999b0165"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -865,7 +865,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.48.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.28.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#b7b14da9b363cd8f13cea3c54a7d9302ed1a316e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6245,7 +6245,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7168,7 +7168,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7180,7 +7180,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "socket2 0.6.5",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7668,7 +7668,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7727,7 +7727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8355,7 +8355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8590,7 +8590,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9402,7 +9402,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -865,7 +865,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.1.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=f472e2677b2aee85817ba868ba31b91da84f1b44#f472e2677b2aee85817ba868ba31b91da84f1b44"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=4ba1e5977520828cec40f426c0e0a27d6dae71f7#4ba1e5977520828cec40f426c0e0a27d6dae71f7"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "6.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.48.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.28.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=release%2F4.0#adefa298ade3d61c45f194000e4feca2cc073a26"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ftest%2Fsession%2F8356-wg-datagram-boundary-repro#442b3c1bc425053437756ece834e897b657e3910"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6245,7 +6245,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7168,7 +7168,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7180,7 +7180,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "socket2 0.6.5",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7668,7 +7668,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7727,7 +7727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8355,7 +8355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8590,7 +8590,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9402,7 +9402,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.5", features = ["derive", "env"] }
 clap_complete = "~4.6.8"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "f472e2677b2aee85817ba868ba31b91da84f1b44", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "4ba1e5977520828cec40f426c0e0a27d6dae71f7", features = [
   "blokli",
   "telemetry",
 ] }
@@ -37,7 +37,7 @@ futures-util = "~0.3.33"
 # commits -- mixing the two builds hoprnet twice and fails with `expected
 # hopr_lib::HoprSessionClientConfig, found HoprSessionClientConfig`. Keep both entries in the
 # same form.
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "release/4.0", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/test/session/8356-wg-datagram-boundary-repro", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "~0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.6", features = ["derive", "env"] }
 clap_complete = "~4.6.9"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "4ba1e5977520828cec40f426c0e0a27d6dae71f7", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "d1e03789dafb415a975ad437fc14d894b3dabb2c", features = [
   "blokli",
   "telemetry",
 ] }
@@ -37,7 +37,7 @@ futures-util = "~0.3.33"
 # commits -- mixing the two builds hoprnet twice and fails with `expected
 # hopr_lib::HoprSessionClientConfig, found HoprSessionClientConfig`. Keep both entries in the
 # same form.
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/test/session/8356-wg-datagram-boundary-repro", features = [
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "release/4.0", features = [
   "runtime-tokio",
 ] }
 human-bandwidth = "~0.1.4"

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -69,7 +69,7 @@ path    = { hops = 1 }
 
 # determine specific connection parameters for persistent main connection
 # [connection.wg]
-# capabilities = [ "segmentation", "no_delay", "datagram" ]
+# capabilities = [ "segmentation", "no_delay" ]
 # target = "172.30.0.1:51820"
 
 # adjust internal session validation ping settings

--- a/documented-config.toml
+++ b/documented-config.toml
@@ -69,7 +69,7 @@ path    = { hops = 1 }
 
 # determine specific connection parameters for persistent main connection
 # [connection.wg]
-# capabilities = [ "segmentation", "no_delay" ]
+# capabilities = [ "segmentation", "no_delay", "datagram" ]
 # target = "172.30.0.1:51820"
 
 # adjust internal session validation ping settings

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,7 @@
                 pkgs.cargo-shear
                 pkgs.jq
                 pkgs.just
+                pkgs.nix-prefetch-git
                 pkgs.rust-analyzer
               ]
               ++ lib.attrValues config.treefmt.build.programs;

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -57,8 +57,6 @@ pub(super) enum Capability {
     NoDelay,
     #[serde(alias = "no_rate_control")]
     NoRateControl,
-    #[serde(alias = "datagram")]
-    Datagram,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -199,7 +197,6 @@ pub(super) fn to_flags(caps: Vec<Capability>) -> SessionCapabilities {
             Capability::RetransmissionAckOnly => SessionCapability::RetransmissionAck,
             Capability::NoDelay => SessionCapability::NoDelay,
             Capability::NoRateControl => SessionCapability::NoRateControl,
-            Capability::Datagram => SessionCapability::Datagram,
         };
         flags |= cap;
     }
@@ -215,10 +212,10 @@ impl Connection {
     }
 
     pub fn default_wg_capabilities() -> Vec<Capability> {
-        // Datagram preserves UDP/WireGuard datagram boundaries over the session (hoprnet#8356):
-        // each datagram is delivered as exactly one read, so neptun never sees a split/coalesced
-        // buffer. Requires a session peer that supports the Datagram capability.
-        vec![Capability::Segmentation, Capability::NoDelay, Capability::Datagram]
+        // NoDelay on a stateless session preserves UDP/WireGuard datagram boundaries over the
+        // session (hoprnet#8356): each datagram is delivered as exactly one read, so neptun never
+        // sees a split/coalesced buffer.
+        vec![Capability::Segmentation, Capability::NoDelay]
     }
 
     pub fn default_bridge_target() -> SessionTarget {

--- a/gnosis_vpn-lib/src/config/v6.rs
+++ b/gnosis_vpn-lib/src/config/v6.rs
@@ -57,6 +57,8 @@ pub(super) enum Capability {
     NoDelay,
     #[serde(alias = "no_rate_control")]
     NoRateControl,
+    #[serde(alias = "datagram")]
+    Datagram,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -197,6 +199,7 @@ pub(super) fn to_flags(caps: Vec<Capability>) -> SessionCapabilities {
             Capability::RetransmissionAckOnly => SessionCapability::RetransmissionAck,
             Capability::NoDelay => SessionCapability::NoDelay,
             Capability::NoRateControl => SessionCapability::NoRateControl,
+            Capability::Datagram => SessionCapability::Datagram,
         };
         flags |= cap;
     }
@@ -212,7 +215,10 @@ impl Connection {
     }
 
     pub fn default_wg_capabilities() -> Vec<Capability> {
-        vec![Capability::Segmentation, Capability::NoDelay]
+        // Datagram preserves UDP/WireGuard datagram boundaries over the session (hoprnet#8356):
+        // each datagram is delivered as exactly one read, so neptun never sees a split/coalesced
+        // buffer. Requires a session peer that supports the Datagram capability.
+        vec![Capability::Segmentation, Capability::NoDelay, Capability::Datagram]
     }
 
     pub fn default_bridge_target() -> SessionTarget {

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,10 +33,10 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=f472e2677b2aee85817ba868ba31b91da84f1b44#f472e2677b2aee85817ba868ba31b91da84f1b44" =
-      "sha256-WS/CG/5kefCcKlRpVUYYJFi7yBb9YCQqaqNidHP8bWQ=";
-    "git+https://github.com/hoprnet/hoprnet?branch=release/4.0#adefa298ade3d61c45f194000e4feca2cc073a26" =
-      "sha256-JXtFX7+TUKMajfmmvaF1hcOQ2Y8li7gpoX/eb9LM+3c=";
+    "git+https://github.com/hoprnet/edge-client.git?rev=d1e03789dafb415a975ad437fc14d894b3dabb2c#d1e03789dafb415a975ad437fc14d894b3dabb2c" =
+      "sha256-hXBI85iORjk6D61E/H+/L9Ri7K7T6orXJq2xnsTeL0k=";
+    "git+https://github.com/hoprnet/hoprnet?branch=release/4.0#08d777e442c251bbd2dc55e36434dbd4999b0165" =
+      "sha256-/vIIwu61MXdOQEYQmwkOTA6VoDjZ4afh7Vn4/G3XRno=";
   };
 
   builders = nixLib.mkRustBuilders {


### PR DESCRIPTION
## Summary

Enables WireGuard-over-HOPR datagram-boundary preservation on the client, fixing the `DecapStalled` tunnel teardowns of #8356.

- **Config:** adds `Capability::Datagram` (serde alias `"datagram"`, `to_flags` → `SessionCapability::Datagram`, and includes it in `default_wg_capabilities`). The WG session now requests `Datagram`, so the exit delivers each UDP datagram to the client as exactly one read — neptun never sees a `frame_mtu`-split buffer, which was the root cause.
- **Deps:** bumps `edgli` to `4ba1e59` ([edge-client#152](https://github.com/hoprnet/edge-client/pull/152)) and repoints `hopr-utils-session` to the `kauki/test/session/8356-wg-datagram-boundary-repro` branch ([hoprnet#8358](https://github.com/hoprnet/hoprnet/pull/8358)), which carry `Capability::Datagram`. Both hopr pins use the **same branch form** to avoid the dual-source build error noted in `Cargo.toml`.

Verified end-to-end on the 2-hop localcluster testenv: the session negotiates `Segmentation | NoDelay | Datagram`, and the `recv_len=1500 decap_failed=true` frame-split failures (the #8356 signature) are eliminated (41,851 clean 1452-byte reads, 0 at 1500). Residual GSO-batch handling is tracked separately (exit-side un-batching).

**Temporary:** branch pins. Move `edgli` + `hopr-utils-session` back to release/4.0 once hoprnet#8358 (and edge-client#152) merge.

Depends on: hoprnet#8358, edge-client#152. Fixes #8356.
