### PR TITLE
fix(session): sustain SURB production through return-path loss

### DIFF
--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -163,11 +163,7 @@ pub(crate) fn to_surb_balancer_config(
     let config = SurbBalancerConfig {
         target_surb_buffer_size: response_buffer.as_u64() / edgli::hopr_lib::exports::transport::SESSION_MTU as u64,
         max_surbs_per_sec,
-        // When the return path starts dropping replies, the Entry balancer's produced-minus-consumed
-        // estimate reads as a filling SURB buffer exactly when the Exit is draining it, so it stops
-        // producing and the Exit starves of SURBs -- the desync behind GNO-713. Opting in lets the
-        // already-wired silent-destination detector force production flat-out until replies resume.
-        sustain_on_return_path_loss: true,
+        sustain_on_return_path_loss: true, // keep producing SURBs when return-path loss hides consumed replies (GNO-713)
         ..Default::default()
     };
     Ok(config)

--- a/gnosis_vpn-lib/src/connection/options.rs
+++ b/gnosis_vpn-lib/src/connection/options.rs
@@ -163,6 +163,11 @@ pub(crate) fn to_surb_balancer_config(
     let config = SurbBalancerConfig {
         target_surb_buffer_size: response_buffer.as_u64() / edgli::hopr_lib::exports::transport::SESSION_MTU as u64,
         max_surbs_per_sec,
+        // When the return path starts dropping replies, the Entry balancer's produced-minus-consumed
+        // estimate reads as a filling SURB buffer exactly when the Exit is draining it, so it stops
+        // producing and the Exit starves of SURBs -- the desync behind GNO-713. Opting in lets the
+        // already-wired silent-destination detector force production flat-out until replies resume.
+        sustain_on_return_path_loss: true,
         ..Default::default()
     };
     Ok(config)


### PR DESCRIPTION
## Summary

  Fixes GNO-713 / gnosis/gnosis_vpn#410 — connections fail or degrade due to
  desynchronized HOPR sessions.

  One-line fix: gnosis_vpn now sets `sustain_on_return_path_loss: true` in the
  SURB balancer config it hands to every session. This activates a recovery
  mechanism that already exists in hopr-lib but was disabled because we built
  the config with `..Default::default()` (the flag defaults `false`).

  ## The bug

  Reported from a macOS client (v0.95.0). The client cycles UK → NL → USA and
  every exit collapses identically:

  1. Inbound WireGuard decap loss is normally low (`estimated_loss` 0.0–0.08),
     then **spikes to 0.55–0.75 right before each teardown** → neptun reports
     `DecapStalled` → `wg pump exited - requesting reconnect reason=DecapStalled`
     → reconnect. Repeat.
  2. The client keeps reporting the connection as up while it is unusable.

  ## Root cause

  The fault is in the **Entry-side SURB balancer**, not WireGuard.

  The balancer estimates the counterparty's (Exit's) SURB stock as
  `produced − consumed`, where `consumed` is incremented only per **received**
  reply packet. When the return path starts dropping replies, those lost
  packets never increment `consumed`, so `produced − consumed` reads as a
  buffer that is *filling* precisely when the Exit is *draining* it.

  Observed end-state balancer sample from the log:

  level=9862 target=9766 output=0 produced=11868 consumed=772 degraded=false

  `level > target` → the controller emits `output=0` → **stops producing SURBS**
