### PR TITLE
chore(deps): bump edgli to edge-client#155 (return-path relayer diversity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -865,7 +865,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2946,8 +2946,8 @@ dependencies = [
 
 [[package]]
 name = "edgli"
-version = "4.1.0"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=d1e03789dafb415a975ad437fc14d894b3dabb2c#d1e03789dafb415a975ad437fc14d894b3dabb2c"
+version = "4.1.1"
+source = "git+https://github.com/hoprnet/edge-client.git?rev=917636aad2eae827542667b1e81793e71d81a324#917636aad2eae827542667b1e81793e71d81a324"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -3118,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6341,7 +6341,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7273,7 +7273,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7285,7 +7285,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "socket2 0.6.5",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7773,7 +7773,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7832,7 +7832,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8461,7 +8461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8696,7 +8696,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.6", features = ["derive", "env"] }
 clap_complete = "~4.6.9"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "d1e03789dafb415a975ad437fc14d894b3dabb2c", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "917636aad2eae827542667b1e81793e71d81a324", features = [
   "blokli",
   "telemetry",
 ] }


### PR DESCRIPTION
## Summary

Points `edgli` at [hoprnet/edge-client#155](https://github.com/hoprnet/edge-client/pull/155),
which lifts the return-path diversity cap in `latency_path_planner_config`
(`min_paths_anonymity_floor` 2 → 0, `latency_halflife` kept a soft 100 ms). A tunnel then keeps
every reachable return relayer instead of collapsing onto the single fastest one — the condition
behind the **2026-08-28 return-path outage**, where hopr-lib's degradation detector had no sibling
relayer to corroborate a dead one against and so never re-planned.

- `edgli` `4.1.0` → `4.1.1` (rev `d1e0378` → `917636a`).
- `hopr-lib` unchanged — still consumed via the `release/4.0` branch pin, so hoprnet is not built
  twice (per the note in `Cargo.toml`).
- Workspace `cargo check` passes against #155.

Generated-config mode (`hopr/config.rs`) inherits the relaxed profile automatically; a manual
hopr-lib config-file TOML supplies its own `protocol.path_planner` and is unaffected.

**Depends on:** hoprnet/edge-client#155 (merge + tag first; this stays draft until then).
Return-path diagnostics land separately via hoprnet/hoprnet#8368 once merged to `release/4.0`.