### PR TITLE
chore(deps): pin edgli to edge-client branch release/4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "edgli"
 version = "4.1.1"
-source = "git+https://github.com/hoprnet/edge-client.git?rev=917636aad2eae827542667b1e81793e71d81a324#917636aad2eae827542667b1e81793e71d81a324"
+source = "git+https://github.com/hoprnet/edge-client.git?branch=release%2F4.1#1e2114196b6739f7349aaf9d67737e38a526a774"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "~0.4.45", default-features = false, features = [
 ] }
 clap = { version = "~4.6.6", features = ["derive", "env"] }
 clap_complete = "~4.6.9"
-edgli = { git = "https://github.com/hoprnet/edge-client.git", rev = "917636aad2eae827542667b1e81793e71d81a324", features = [
+edgli = { git = "https://github.com/hoprnet/edge-client.git", branch = "release/4.1", features = [
   "blokli",
   "telemetry",
 ] }

--- a/nix/gnosisvpn.nix
+++ b/nix/gnosisvpn.nix
@@ -33,7 +33,7 @@ let
   outputHashes = {
     "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293" =
       "sha256-QF8BAe2eHrGsVvZIGD+Gdi6XFMQ8zHkOObSRjTRN4MY=";
-    "git+https://github.com/hoprnet/edge-client.git?rev=917636aad2eae827542667b1e81793e71d81a324#917636aad2eae827542667b1e81793e71d81a324" =
+    "git+https://github.com/hoprnet/edge-client.git?branch=release/4.1#1e2114196b6739f7349aaf9d67737e38a526a774" =
       "sha256-m5oC/er9iDnpzo/jj0MTI5ktYSa88a+PXTLOucYwipM=";
     "git+https://github.com/hoprnet/hoprnet?branch=release/4.0#08d777e442c251bbd2dc55e36434dbd4999b0165" =
       "sha256-/vIIwu61MXdOQEYQmwkOTA6VoDjZ4afh7Vn4/G3XRno=";


### PR DESCRIPTION
Repoints `edgli` from a dangling PR rev (`917636aa`, the pre-squash head of edge-client#155) to the `release/4.1` branch, locking its tip `1e211419`. Both commits have identical trees, so the vendored content — and its nix output hash — is unchanged; only the source key moves to `?branch=release/4.1`.

This keeps the stable line on edge-client's v4 maintenance branch: future edge-client v4 fixes land here via a plain `cargo update edgli` relock instead of hand-picked revs. edge-client `release/4.1` pins hopr-lib at `branch = "release/4.0"` — the same form and branch as our `hopr-utils-session` pin, so the branch-vs-rev double-build gotcha documented in Cargo.toml stays satisfied. The hoprnet lock stays at `08d777e4` (re-pinned after `cargo update` floated it as a side effect).